### PR TITLE
Fix when registry is empty will cause panic

### DIFF
--- a/registry/etcd/etcd.go
+++ b/registry/etcd/etcd.go
@@ -114,6 +114,10 @@ func (e *etcdRegistry) GetService(name string) ([]*registry.Service, error) {
 	if err != nil && !strings.HasPrefix(err.Error(), "100: Key not found") {
 		return nil, err
 	}
+	
+	if rsp == nil {
+		return nil, registry.ErrNotFound
+	}
 
 	serviceMap := map[string]*registry.Service{}
 


### PR DESCRIPTION
When registry is empty will return registry.ErrNotFound.