### PR TITLE
Fixed: Sometimes etcd get service list is error.

### DIFF
--- a/registry/etcd/etcd.go
+++ b/registry/etcd/etcd.go
@@ -90,7 +90,7 @@ func (e *etcdRegistry) Register(s *registry.Service, opts ...registry.RegisterOp
 	ctx, cancel := context.WithTimeout(context.Background(), e.options.Timeout)
 	defer cancel()
 
-	_, err := e.client.Set(ctx, servicePath(s.Name), "", &etcd.SetOptions{PrevExist: etcd.PrevIgnore, Dir: true, TTL: options.TTL})
+	_, err := e.client.Set(ctx, servicePath(s.Name), "", &etcd.SetOptions{PrevExist: etcd.PrevIgnore, Dir: true})
 	if err != nil && !strings.HasPrefix(err.Error(), "102: Not a file") {
 		return err
 	}


### PR DESCRIPTION
I use etcd 2.2.5 with docker. It will happen sometimes when i query other service node. The etcd server doesn't refresh dir ttl time, but don't know is refreshed in other version.
So I suggest removed it temporary.