### PR TITLE
Allow multi registration with k8s plugin

### DIFF
--- a/registry/kubernetes/client/client.go
+++ b/registry/kubernetes/client/client.go
@@ -14,6 +14,7 @@ import (
 type Kubernetes interface {
 	GetEndpoints(serviceName string) (*Endpoints, error)
 	UpdatePod(podName string, pod *Pod) error
+	GetPod(name string) (*Pod, error)
 	GetPods(labels map[string]string) (*PodList, error)
 	GetServices() (*ServiceList, error)
 	WatchEndpoints() (*WatchRequest, error)
@@ -105,6 +106,7 @@ type Item struct {
 // Meta ...
 type Meta struct {
 	Name        string            `json:"name,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 

--- a/registry/kubernetes/client/http.go
+++ b/registry/kubernetes/client/http.go
@@ -29,9 +29,22 @@ func (k *Client) GetEndpoints(serviceName string) (*Endpoints, error) {
 	return &data, nil
 }
 
+// GetPod returns a single pod by name
+func (k *Client) GetPod(name string) (*Pod, error) {
+	url, err := k.buildURL("pods/" + name)
+	if err != nil {
+		return nil, err
+	}
+	var pod Pod
+	if err := k.get(url, &pod); err != nil {
+		return nil, err
+	}
+	return &pod, nil
+}
+
 // UpdatePod issues a PATCH to "/pods/{name}"
-func (k *Client) UpdatePod(podName string, pod *Pod) error {
-	url, err := k.buildURL("pods/" + podName)
+func (k *Client) UpdatePod(name string, pod *Pod) error {
+	url, err := k.buildURL("pods/" + name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a rework of the k8s plugin so it will allow registration of multiple things. It can be useful where the HTTP broker is to be used or other info is to be maintained in local state.