### PR TITLE
use etcd plugin on windows,occur a mistake

### DIFF
--- a/registry/etcd/etcd.go
+++ b/registry/etcd/etcd.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net"
 	"net/http"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -44,11 +43,12 @@ func decode(ds string) *registry.Service {
 func nodePath(s, id string) string {
 	service := strings.Replace(s, "/", "-", -1)
 	node := strings.Replace(id, "/", "-", -1)
-	return filepath.Join(prefix, service, node)
+	return strings.Join([]string{prefix, service, node}, "/")
 }
 
 func servicePath(s string) string {
-	return filepath.Join(prefix, strings.Replace(s, "/", "-", -1))
+	service := strings.Replace(s, "/", "-", -1)
+	return strings.Join([]string{prefix, service}, "/")
 }
 
 func (e *etcdRegistry) Deregister(s *registry.Service) error {


### PR DESCRIPTION
build on windows,it will generates like "/\\micro-registry\\go.micro.srv.auth" dir in etcd. it will makes a mistake as you use client to find the service