### PR TITLE
Kubernetes Registry Further improvements - Pods only.

### DIFF
--- a/registry/kubernetes/README.md
+++ b/registry/kubernetes/README.md
@@ -8,7 +8,6 @@ to build a service discovery mechanism.
 
 
 ## Gotchas
-* You can only Register/Deregister one node at a time.
 * Registering/Deregistering relies on the HOSTNAME Environment Variable, which inside a pod
 is the place where it can be retrieved from. (This needs improving)
 

--- a/registry/kubernetes/README.md
+++ b/registry/kubernetes/README.md
@@ -3,27 +3,15 @@ This is a plugin for go-micro that allows you to use Kubernetes as a registry.
 
 
 ## Overview
-This registry plugin makes use of Kubernetes Services and Endpoints to build a
-service discovery mechanism. Endpoints are automatically created by Kubernetes
-when a Service is created. Endpoints returns a list of IP and ports for a
-service matching the services Label Selector.
+This registry plugin makes use of Annotations and Labels on a Kubernetes pod
+to build a service discovery mechanism.
 
-When `.Register()` is called, a K8s Service is created if one doesn't already exist.
-For each service instance, an annotation is added to the endpoints object. The Label
-Selector is added to the labels on the pod the micro service is running in, this
-allows the pod to be found by the service.
-All this together allows the plugin to build a complete `registry.Service` with all the nodes,
-with one call to the K8s API.
 
 ## Gotchas
 * You can only Register/Deregister one node at a time.
 * Registering/Deregistering relies on the HOSTNAME Environment Variable, which inside a pod
 is the place where it can be retrieved from. (This needs improving)
-* Kubernetes Services wont get removed when a micro service is completed stopped
-* This plugin will store annotations on the K8s endpoints object, sometimes they might
-hang around, but there is a cleanup process when micro services are registered.
-* Kubernetes Services/Endpoints are linked in various ways, for example they
-share a name and labels, but they do not share annotations.
+
 
 ## Connecting to the Kubernetes API
 ### Within a pod

--- a/registry/kubernetes/client/api/request.go
+++ b/registry/kubernetes/client/api/request.go
@@ -178,7 +178,7 @@ func (r *Request) Watch() (watch.Watch, error) {
 		return nil, err
 	}
 
-	w, err := watch.NewBodyWatcher(req)
+	w, err := watch.NewBodyWatcher(req, r.client)
 	return w, err
 }
 

--- a/registry/kubernetes/client/client.go
+++ b/registry/kubernetes/client/client.go
@@ -18,6 +18,13 @@ type client struct {
 	opts *api.Options
 }
 
+// ListPods ...
+func (c *client) ListPods(labels map[string]string) (*PodList, error) {
+	var pods PodList
+	err := api.NewRequest(c.opts).Get().Resource("pods").Params(&api.Params{LabelSelector: labels}).Do().Into(&pods)
+	return &pods, err
+}
+
 // UpdatePod ...
 func (c *client) UpdatePod(name string, p *Pod) (*Pod, error) {
 	var pod Pod
@@ -25,44 +32,9 @@ func (c *client) UpdatePod(name string, p *Pod) (*Pod, error) {
 	return &pod, err
 }
 
-// CreateService ...
-func (c *client) CreateService(s *Service) (*Service, error) {
-	var service Service
-	err := api.NewRequest(c.opts).Post().Resource("services").Body(s).Do().Into(&service)
-	return &service, err
-}
-
-// UpdateService ...
-func (c *client) UpdateService(name string, s *Service) (*Service, error) {
-	var service Service
-	err := api.NewRequest(c.opts).Patch().Resource("services").Name(name).Body(s).Do().Into(&service)
-	return &service, err
-}
-
-// ListEndpoints ...
-func (c *client) ListEndpoints(labels map[string]string) (*EndpointsList, error) {
-	var endpoints EndpointsList
-	err := api.NewRequest(c.opts).Get().Resource("endpoints").Params(&api.Params{LabelSelector: labels}).Do().Into(&endpoints)
-	return &endpoints, err
-}
-
-// GetEndpoints ...
-func (c *client) GetEndpoints(name string) (*Endpoints, error) {
-	var endpoints Endpoints
-	err := api.NewRequest(c.opts).Get().Resource("endpoints").Name(name).Do().Into(&endpoints)
-	return &endpoints, err
-}
-
-// UpdateEndpoints ...
-func (c *client) UpdateEndpoints(name string, s *Endpoints) (*Endpoints, error) {
-	var endpoints Endpoints
-	err := api.NewRequest(c.opts).Patch().Resource("endpoints").Name(name).Body(s).Do().Into(&endpoints)
-	return &endpoints, err
-}
-
-// WatchEndpoints ...
-func (c *client) WatchEndpoints(labels map[string]string) (watch.Watch, error) {
-	return api.NewRequest(c.opts).Get().Resource("endpoints").Params(&api.Params{LabelSelector: labels}).Watch()
+// WatchPods ...
+func (c *client) WatchPods(labels map[string]string) (watch.Watch, error) {
+	return api.NewRequest(c.opts).Get().Resource("pods").Params(&api.Params{LabelSelector: labels}).Watch()
 }
 
 // NewClientByHost sets up a client by host

--- a/registry/kubernetes/client/kubernetes.go
+++ b/registry/kubernetes/client/kubernetes.go
@@ -4,76 +4,9 @@ import "github.com/micro/go-plugins/registry/kubernetes/client/watch"
 
 // Kubernetes ...
 type Kubernetes interface {
+	ListPods(labels map[string]string) (*PodList, error)
 	UpdatePod(podName string, pod *Pod) (*Pod, error)
-
-	CreateService(s *Service) (*Service, error)
-	UpdateService(name string, s *Service) (*Service, error)
-
-	ListEndpoints(labels map[string]string) (*EndpointsList, error)
-	GetEndpoints(name string) (*Endpoints, error)
-	UpdateEndpoints(name string, s *Endpoints) (*Endpoints, error)
-	WatchEndpoints(labels map[string]string) (watch.Watch, error)
-}
-
-// Meta ...
-type Meta struct {
-	Name        string             `json:"name,omitempty"`
-	Labels      map[string]*string `json:"labels,omitempty"`
-	Annotations map[string]*string `json:"annotations,omitempty"`
-}
-
-// Endpoints ...
-type Endpoints struct {
-	Metadata *Meta    `json:"metadata"`
-	Subsets  []Subset `json:"subsets,omitempty"`
-}
-
-// EndpointsList ...
-type EndpointsList struct {
-	Items []Endpoints `json:"items"`
-}
-
-// Service ...
-type Service struct {
-	Metadata *Meta        `json:"metadata"`
-	Spec     *ServiceSpec `json:"spec,omitempty"`
-}
-
-// ServiceSpec ...
-type ServiceSpec struct {
-	Ports     []Port            `json:"ports"`
-	Selector  map[string]string `json:"selector,omitempty"`
-	ClusterIP string            `json:"clusterIP"`
-}
-
-// Port ...
-type Port struct {
-	Name       string      `json:"name,omitempty"`
-	Port       int         `json:"port"`
-	TargetPort interface{} `json:"targetPort"`
-}
-
-// Subset ...
-type Subset struct {
-	Addresses []Address    `json:"addresses"`
-	Ports     []SubsetPort `json:"ports"`
-}
-
-// Address ...
-type Address struct {
-	TargetRef ObjectRef `json:"targetRef"`
-	IP        string    `json:"ip"`
-}
-
-// ObjectRef ... used as part of the endpoint address to identify pod
-type ObjectRef struct {
-	Name string
-}
-
-// SubsetPort ...
-type SubsetPort struct {
-	Name string `json:"name,omitempty"`
-	Port int    `json:"port"`
+	WatchPods(labels map[string]string) (watch.Watch, error)
 }
 
 // PodList ...
@@ -87,7 +20,15 @@ type Pod struct {
 	Status   *Status `json:"status"`
 }
 
+// Meta ...
+type Meta struct {
+	Name        string             `json:"name,omitempty"`
+	Labels      map[string]*string `json:"labels,omitempty"`
+	Annotations map[string]*string `json:"annotations,omitempty"`
+}
+
 // Status ...
 type Status struct {
 	PodIP string `json:"podIP"`
+	Phase string `json:"phase"`
 }

--- a/registry/kubernetes/client/mock/utils.go
+++ b/registry/kubernetes/client/mock/utils.go
@@ -54,40 +54,6 @@ func updateMetadata(a, b *client.Meta) {
 	}
 }
 
-func updateMockMetadata(a *mockMeta, b *client.Meta) {
-	if a == nil || b == nil {
-		return
-	}
-
-	if b.Labels != nil {
-		labels := *a.Labels
-		if a.Labels != nil {
-			for lk, lv := range b.Labels {
-				if labels != nil && lv == nil {
-					delete(labels, lk)
-					continue
-				}
-				labels[lk] = lv
-			}
-		}
-
-	}
-
-	if b.Annotations != nil {
-		ann := a.Annotations
-		if ann == nil {
-			a.Annotations = map[string]*string{}
-		}
-		for ak, av := range b.Annotations {
-			if av == nil {
-				delete(ann, ak)
-				continue
-			}
-			a.Annotations[ak] = av
-		}
-	}
-}
-
 func labelFilterMatch(a map[string]*string, b map[string]string) bool {
 	match := true
 	for lk, lv := range b {

--- a/registry/kubernetes/client/watch/watch.go
+++ b/registry/kubernetes/client/watch/watch.go
@@ -1,5 +1,7 @@
 package watch
 
+import "encoding/json"
+
 // Watch ...
 type Watch interface {
 	Stop()
@@ -19,6 +21,6 @@ const (
 
 // Event represents a single event to a watched resource.
 type Event struct {
-	Type   EventType   `json:"type"`
-	Object interface{} `json:"object"`
+	Type   EventType       `json:"type"`
+	Object json.RawMessage `json:"object"`
 }

--- a/registry/kubernetes/client/watch/watch_test.go
+++ b/registry/kubernetes/client/watch/watch_test.go
@@ -43,10 +43,12 @@ func TestBodyWatcher(t *testing.T) {
 	}
 
 	// setup body watcher
-	w, err := NewBodyWatcher(req)
+	w, err := NewBodyWatcher(req, http.DefaultClient)
 	if err != nil {
 		t.Fatalf("did not expect NewBodyWatcher to return %v", err)
 	}
+
+	<-time.After(time.Second)
 
 	// send action strings in, and expect result back
 	ch <- actions[0]

--- a/registry/kubernetes/watcher.go
+++ b/registry/kubernetes/watcher.go
@@ -37,7 +37,6 @@ func (k *k8sWatcher) updateCache() ([]*registry.Result, error) {
 		rslts := k.buildPodResults(&pod, nil)
 
 		for _, r := range rslts {
-			log.Printf("K8s Watcher ResultItem: %s -> %s -> %s:%s", r.Action, pod.Metadata.Name, r.Service.Name, r.Service.Nodes[0].Address)
 			results = append(results, r)
 		}
 
@@ -159,8 +158,6 @@ func (k *k8sWatcher) handleEvent(event watch.Event) {
 			if pod.Status.Phase != podRunning {
 				result.Action = "delete"
 			}
-
-			log.Printf("K8s Watcher Mod: %s -> %s -> %s", result.Action, result.Service.Name, pod.Metadata.Name)
 			k.next <- result
 		}
 
@@ -176,7 +173,6 @@ func (k *k8sWatcher) handleEvent(event watch.Event) {
 
 		for _, result := range results {
 			result.Action = "delete"
-			log.Printf("K8s Watcher Del: %s -> %s", result.Action, result.Service.Nodes[0].Id)
 			k.next <- result
 		}
 


### PR DESCRIPTION
This drastically simplifies the registry and is probably closer to what @asim had in mind.

The main difference is that this version only touches the Pods API. Annotations are stored on the pods, with the ability to have multiple services running inside a single pod. No more K8s Services or Endpoints.

This also fixes some bugs from the previous version with the watchers.

I wasn't happy with how complicated the current version is and it was sitting right with me. I'm pretty sure I've finished tinkering now, there is only so much registry I can take.