### PR TITLE
Add required instance details in serviceToInstance

### DIFF
--- a/registry/eureka/marshalling.go
+++ b/registry/eureka/marshalling.go
@@ -3,6 +3,7 @@ package eureka
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/hudl/fargo"
@@ -79,19 +80,23 @@ func serviceToInstance(service *registry.Service) (*fargo.Instance, error) {
 
 	instance := &fargo.Instance{
 		App:              service.Name,
+		HostName:         node.Address,
 		IPAddr:           node.Address,
 		VipAddress:       node.Address,
 		SecureVipAddress: node.Address,
 		Port:             node.Port,
 		Status:           fargo.UP,
 		UniqueID: func(i fargo.Instance) string {
-			return node.Id
+			return fmt.Sprintf("%s:%s", node.Address, node.Id)
 		},
 		DataCenterInfo: fargo.DataCenterInfo{Name: fargo.MyOwn},
 	}
 
 	// set version
 	instance.SetMetadataString("version", service.Version)
+
+	// set instance ID
+	instance.SetMetadataString("instanceId", node.Id)
 
 	// set endpoints
 	if b, err := json.Marshal(service.Endpoints); err == nil {

--- a/registry/eureka/marshalling_test.go
+++ b/registry/eureka/marshalling_test.go
@@ -1,0 +1,87 @@
+package eureka
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/hudl/fargo"
+	"github.com/micro/go-micro/registry"
+)
+
+func TestServiceToInstance(t *testing.T) {
+	nodes := []*registry.Node{
+		&registry.Node{
+			Id:       "node0",
+			Address:  "node0.example.com",
+			Port:     1234,
+			Metadata: map[string]string{"foo": "bar"},
+		},
+		&registry.Node{
+			Id:      "node1",
+			Address: "node1.example.com",
+			Port:    9876,
+		},
+	}
+
+	endpoints := []*registry.Endpoint{
+		&registry.Endpoint{
+			Name:     "endpoint",
+			Request:  &registry.Value{"request-value", "request-value-type", []*registry.Value{}},
+			Response: &registry.Value{"response-value", "response-value-type", []*registry.Value{}},
+			Metadata: map[string]string{"endpoint-meta-key": "endpoint-meta-value"},
+		},
+	}
+
+	service := &registry.Service{
+		Name:      "service-name",
+		Version:   "service-version",
+		Nodes:     nodes,
+		Endpoints: endpoints,
+	}
+
+	instance, err := serviceToInstance(service)
+	if err != nil {
+		t.Error("Unexpected serviceToInstance error:", err)
+	}
+
+	instanceMetadata := instance.Metadata.GetMap()
+
+	expectedUniqueID := fmt.Sprintf("%s:%s", nodes[0].Address, nodes[0].Id)
+
+	expectedEndpointsJSON, err := json.Marshal(endpoints)
+	if err != nil {
+		t.Error("Unexpected endpoints marshal error:", err)
+	}
+
+	expectedNodeMetadataJSON, err := json.Marshal(nodes[0].Metadata)
+	if err != nil {
+		t.Error("Unexpected node metadata marshal error:", err)
+	}
+
+	testData := []struct {
+		name string
+		want interface{}
+		got  interface{}
+	}{
+		{"instance.App", service.Name, instance.App},
+		{"instance.HostName", nodes[0].Address, instance.HostName},
+		{"instance.IPAddr", nodes[0].Address, instance.IPAddr},
+		{"instance.VipAddress", nodes[0].Address, instance.VipAddress},
+		{"instance.SecureVipAddress", nodes[0].Address, instance.SecureVipAddress},
+		{"instance.Port", nodes[0].Port, instance.Port},
+		{"instance.Status", fargo.UP, instance.Status},
+		{"instance.UniqueID()", expectedUniqueID, instance.UniqueID(*instance)},
+		{"instance.DataCenteInfo.Name", fargo.MyOwn, instance.DataCenterInfo.Name},
+		{`instance.Metadata["version"]`, service.Version, instanceMetadata["version"]},
+		{`instance.Metadata["instanceId"]`, nodes[0].Id, instanceMetadata["instanceId"]},
+		{`instance.Metadata["endpoints"]`, string(expectedEndpointsJSON), instanceMetadata["endpoints"]},
+		{`instance.Metadata["metadata"]`, string(expectedNodeMetadataJSON), instanceMetadata["metadata"]},
+	}
+
+	for _, test := range testData {
+		if test.got != test.want {
+			t.Errorf("Unexpected %s: want %v, got %v", test.name, test.want, test.got)
+		}
+	}
+}


### PR DESCRIPTION
Hi Asim, just a few minor changes/additions to `eureka.serviceToInstance`:

* HostName is required
* UniqueID must be concatenation of address and id (see http://bit.ly/1QdWnnt)
* Metadata must have `instanceId` field