### PR TITLE
API Router Plugin

### DIFF
--- a/micro/router/README.md
+++ b/micro/router/README.md
@@ -1,0 +1,24 @@
+# Router Plugin
+
+The router plugin is a HTTP handler plugin for the Micro API which enables you to define routes via go-platform/config. This is 
+dynamic configuration that can then be leveraged via anything that implements the go-platform/config interface e.g file, etcd, consul 
+or the config service.
+
+## Usage
+
+Register the plugin before building Micro
+
+```
+package main
+
+import (
+	"github.com/micro/micro/plugin"
+	"github.com/micro/go-plugins/micro/router"
+)
+
+func init() {
+	plugin.Register(router.NewRouter())
+}
+```
+
+

--- a/micro/router/README.md
+++ b/micro/router/README.md
@@ -64,7 +64,8 @@ Routes are used to config request to match and the response to return. Here's an
 					"header": {
 						"location": "http://example.com"
 					}
-				}
+				},
+				"weight": 1.0
 			},
 			{
 				"request": {
@@ -77,7 +78,8 @@ Routes are used to config request to match and the response to return. Here's an
 					"header": {
 						"location": "http://foo.bar.com"
 					}
-				}
+				},
+				"weight": 1.0
 			}
 		]
 	}

--- a/micro/router/README.md
+++ b/micro/router/README.md
@@ -4,6 +4,19 @@ The router plugin is a HTTP handler plugin for the Micro API which enables you t
 dynamic configuration that can then be leveraged via anything that implements the go-platform/config interface e.g file, etcd, consul 
 or the config service.
 
+## Features
+
+- Request Matching
+- Weighted Routing
+- Reverse Proxying
+- Priority Rules
+- Configurable via go-platform/Config
+- Pluggable via micro/plugins
+
+## TODO
+
+- Regex Matching Host/Path
+
 ## Usage
 
 Register the plugin before building Micro

--- a/micro/router/README.md
+++ b/micro/router/README.md
@@ -8,7 +8,7 @@ or the config service.
 
 Register the plugin before building Micro
 
-```
+```go
 package main
 
 import (
@@ -19,6 +19,30 @@ import (
 func init() {
 	plugin.Register(router.NewRouter())
 }
+```
+
+## Config
+
+Configuring the router is done via a go-platform/Config source. Here's an example using the File source.
+
+```go
+// Create Config Source
+f := file.NewSource(
+	// Use routes.json file
+	config.SourceName("routes.json"),
+)
+
+// Create Config
+c := config.NewConfig(
+	// With Source
+	config.WithSource(f),
+)
+
+// Create Router
+r := router.NewRouter(
+	// With Config
+	router.Config(c),
+)
 ```
 
 ## Routes

--- a/micro/router/README.md
+++ b/micro/router/README.md
@@ -21,4 +21,41 @@ func init() {
 }
 ```
 
+## Routes
 
+Routes are used to config request to match and the response to return. Here's an example.
+
+```json
+{
+	"api": {
+		"routes": [
+			{
+				"request": {
+					"method": "GET",
+					"host": "127.0.0.1:10001",
+					"path": "/"
+				},
+				"response": {
+					"status_code": 302,
+					"header": {
+						"location": "http://example.com"
+					}
+				}
+			},
+			{
+				"request": {
+					"method": "POST",
+					"host": "127.0.0.1:10001",
+					"path": "/foo"
+				},
+				"response": {
+					"status_code": 301,
+					"header": {
+						"location": "http://foo.bar.com"
+					}
+				}
+			}
+		]
+	}
+}
+```

--- a/micro/router/examples/README.md
+++ b/micro/router/examples/README.md
@@ -1,0 +1,4 @@
+# Example
+
+The example API router uses [File](https://godoc.org/github.com/micro/go-platform/config/source/file) config source to load routes.json and 
+runs on 127.0.0.1:10001. If you hit / you'll be redirected to example.com as expected.

--- a/micro/router/examples/router.go
+++ b/micro/router/examples/router.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/micro/go-platform/config"
+	"github.com/micro/go-platform/config/source/file"
+	"github.com/micro/go-plugins/micro/router"
+)
+
+func main() {
+	// Create listener
+	l, err := net.Listen("tcp", "localhost:10001")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer l.Close()
+
+	// Create Config Source
+	f := file.NewSource(config.SourceName("routes.json"))
+	conf := config.NewConfig(config.WithSource(f))
+
+	// Create Router
+	r := router.NewRouter(router.Config(conf))
+
+	// Setup Handler
+	wr := r.Handler()
+	h := wr(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", 404)
+	}))
+
+	// Start Server
+	if err := http.Serve(l, h); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/micro/router/examples/routes.json
+++ b/micro/router/examples/routes.json
@@ -12,7 +12,8 @@
 					"header": {
 						"location": "http://example.com"
 					}
-				}
+				},
+				"weight": 1.0
 			},
 			{
 				"request": {
@@ -25,7 +26,8 @@
 					"header": {
 						"location": "http://foo.bar.com"
 					}
-				}
+				},
+				"weight": 1.0
 			}
 		]
 	}

--- a/micro/router/examples/routes.json
+++ b/micro/router/examples/routes.json
@@ -1,0 +1,32 @@
+{
+	"api": {
+		"routes": [
+			{
+				"request": {
+					"method": "GET",
+					"host": "127.0.0.1:10001",
+					"path": "/"
+				},
+				"response": {
+					"status_code": 302,
+					"header": {
+						"location": "http://example.com"
+					}
+				}
+			},
+			{
+				"request": {
+					"method": "POST",
+					"host": "127.0.0.1:10001",
+					"path": "/foo"
+				},
+				"response": {
+					"status_code": 301,
+					"header": {
+						"location": "http://foo.bar.com"
+					}
+				}
+			}
+		]
+	}
+}

--- a/micro/router/examples/routes.json
+++ b/micro/router/examples/routes.json
@@ -28,6 +28,20 @@
 					}
 				},
 				"weight": 1.0
+			},
+			{
+				"request": {
+					"method": "GET",
+					"host": "127.0.0.1:10001",
+					"path": "/foobar"
+				},
+				"proxy_url": {
+					"scheme": "http",
+					"host": "www.google.com",
+					"path": "/"
+				},
+				"weight": 1.0,
+				"type": "proxy"
 			}
 		]
 	}

--- a/micro/router/options.go
+++ b/micro/router/options.go
@@ -1,0 +1,15 @@
+package router
+
+import (
+	"github.com/micro/go-platform/config"
+)
+
+type Options struct {
+	Config config.Config
+}
+
+func Config(c config.Config) Option {
+	return func(o *Options) {
+		o.Config = c
+	}
+}

--- a/micro/router/router.go
+++ b/micro/router/router.go
@@ -1,0 +1,57 @@
+// Package router is a micro plugin for defining HTTP routes
+package router
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/micro/cli"
+	"github.com/micro/micro/plugin"
+)
+
+type Option func(o *Options)
+
+type router struct {
+	opts Options
+}
+
+func (r *router) Flags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:   "config_source",
+			EnvVar: "CONFIG_SOURCE",
+			Usage:  "Source to read the config from e.g file, platform",
+		},
+	}
+}
+
+func (r *router) Commands() []cli.Command {
+	return nil
+}
+
+func (r *router) Handler() plugin.Handler {
+	return func(h http.Handler) http.Handler {
+		return h
+	}
+}
+
+func (r *router) Init(ctx *cli.Context) error {
+	if c := ctx.String("config_source"); len(c) == 0 && r.opts.Config == nil {
+		return errors.New("config source must be defined")
+	}
+	return nil
+}
+
+func (r *router) String() string {
+	return "router"
+}
+
+func NewRouter(opts ...Option) plugin.Plugin {
+	var options Options
+	for _, o := range opts {
+		o(&options)
+	}
+	return &router{
+		opts: options,
+	}
+}

--- a/micro/router/router.go
+++ b/micro/router/router.go
@@ -176,7 +176,17 @@ func NewRouter(opts ...Option) plugin.Plugin {
 	for _, o := range opts {
 		o(&options)
 	}
-	return &router{
+
+	r := &router{
 		opts: options,
 	}
+
+	if options.Config != nil {
+		var routes Routes
+		if err := options.Config.Get(DefaultPath...).Scan(&routes); err == nil {
+			r.update(routes)
+		}
+	}
+
+	return r
 }

--- a/micro/router/router.go
+++ b/micro/router/router.go
@@ -4,8 +4,15 @@ package router
 import (
 	"errors"
 	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/micro/cli"
+	"github.com/micro/go-platform/config"
+	"github.com/micro/go-platform/config/source/file"
+	"github.com/micro/go-platform/log"
 	"github.com/micro/micro/plugin"
 )
 
@@ -13,6 +20,78 @@ type Option func(o *Options)
 
 type router struct {
 	opts Options
+
+	// TODO: optimise for concurrency
+	sync.RWMutex
+	routes Routes
+}
+
+var (
+	// Default config source file
+	DefaultFile   = "routes.json"
+	DefaultPath   = []string{"api"}
+	DefaultLogger = log.NewLog(log.WithOutput(log.NewOutput(log.OutputName("/dev/stderr"))))
+)
+
+func (r *router) update(routes Routes) {
+	// sort routes
+	sort.Sort(sortedRoutes{routes})
+	// update
+	r.Lock()
+	r.routes = routes
+	r.Unlock()
+}
+
+func (r *router) run(c config.Config) {
+	var routes Routes
+
+	// load routes immediately if possible
+	if err := c.Get(DefaultPath...).Scan(&routes); err != nil {
+		DefaultLogger.Error("[router] Failed to get routes", err)
+	} else {
+		r.update(routes)
+	}
+
+	var watcher config.Watcher
+
+	// try to get a watch
+	for i := 0; i < 100; i++ {
+		w, err := c.Watch(DefaultPath...)
+		if err != nil {
+			DefaultLogger.Error("[router] Failed to get watcher", err)
+			time.Sleep(time.Second)
+			continue
+		}
+		watcher = w
+		break
+	}
+
+	// if the watch is nil we exit
+	if watcher == nil {
+		DefaultLogger.Fatal("[router] Failed to get watcher in 100 attempts")
+	}
+
+	// watch and update routes
+	for {
+		// get next
+		v, err := watcher.Next()
+		if err != nil {
+			DefaultLogger.Error("[router] Watcher Next() Error", err)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		var routes Routes
+
+		// scan into routes
+		if err := v.Scan(&routes); err != nil {
+			DefaultLogger.Error("[router] Failed to scan routes... skipping update", err)
+			continue
+		}
+
+		// update the routes
+		r.update(routes)
+	}
 }
 
 func (r *router) Flags() []cli.Flag {
@@ -20,7 +99,7 @@ func (r *router) Flags() []cli.Flag {
 		cli.StringFlag{
 			Name:   "config_source",
 			EnvVar: "CONFIG_SOURCE",
-			Usage:  "Source to read the config from e.g file, platform",
+			Usage:  "Source to read the config from e.g file:path/to/file, platform",
 		},
 	}
 }
@@ -31,14 +110,60 @@ func (r *router) Commands() []cli.Command {
 
 func (r *router) Handler() plugin.Handler {
 	return func(h http.Handler) http.Handler {
-		return h
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			// get routes
+			r.RLock()
+			routes := r.routes
+			r.RUnlock()
+
+			// routes are ordered on update
+			for _, route := range routes.Routes {
+				// route matched write and return
+				if route.Match(req) {
+					route.Write(w, req)
+					return
+				}
+			}
+
+			// serve the default handler
+			h.ServeHTTP(w, req)
+		})
 	}
 }
 
 func (r *router) Init(ctx *cli.Context) error {
+	// TODO: Make this more configurable and add more sources
+	var conf config.Config
+
 	if c := ctx.String("config_source"); len(c) == 0 && r.opts.Config == nil {
 		return errors.New("config source must be defined")
+	} else if len(c) > 0 {
+		var source config.Source
+
+		switch c {
+		case "platform":
+			source = config.NewSource()
+		case "file":
+			fileName := DefaultFile
+
+			parts := strings.Split(c, ":")
+
+			if len(parts) > 1 {
+				fileName = parts[1]
+			}
+
+			source = file.NewSource(config.SourceName(fileName))
+		default:
+			return errors.New("Unknown config source " + c)
+		}
+
+		conf = config.NewConfig(config.WithSource(source))
+	} else {
+		conf = r.opts.Config
 	}
+
+	go r.run(conf)
+
 	return nil
 }
 

--- a/micro/router/router_test.go
+++ b/micro/router/router_test.go
@@ -1,0 +1,108 @@
+package router
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/micro/go-platform/config"
+	"github.com/micro/go-platform/config/source/memory"
+)
+
+func TestRouter(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	routes := []Route{
+		{
+			Request: Request{
+				Method: "GET",
+				Host:   l.Addr().String(),
+				Path:   "/",
+			},
+			Response: Response{
+				StatusCode: 302,
+				Header: map[string]string{
+					"Location": "http://example.com",
+				},
+			},
+		},
+		{
+			Request: Request{
+				Method: "POST",
+				Host:   l.Addr().String(),
+				Path:   "/bar",
+			},
+			Response: Response{
+				StatusCode: 301,
+				Header: map[string]string{
+					"Location": "http://foo.bar.com",
+				},
+			},
+		},
+	}
+
+	apiConfig := map[string]interface{}{
+		"api": map[string]interface{}{
+			"routes": routes,
+		},
+	}
+
+	b, _ := json.Marshal(apiConfig)
+	m := memory.NewSource()
+	m.Update(b)
+	conf := config.NewConfig(config.WithSource(m))
+	r := NewRouter(Config(conf))
+
+	wr := r.Handler()
+	h := wr(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", 404)
+	}))
+
+	go http.Serve(l, h)
+
+	ErrRedirect := errors.New("redirect")
+
+	c := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return ErrRedirect
+		},
+	}
+
+	for _, route := range routes {
+		var rsp *http.Response
+		var err error
+
+		switch route.Request.Method {
+		case "GET":
+			rsp, err = c.Get("http://" + route.Request.Host + route.Request.Path)
+		case "POST":
+			rsp, err = c.Post("http://"+route.Request.Host+route.Request.Path, "application/json", bytes.NewBuffer(nil))
+		}
+
+		if err != nil {
+			urlErr, ok := err.(*url.Error)
+			if ok && urlErr.Err == ErrRedirect {
+				// skip
+			} else {
+				t.Fatal(err)
+			}
+		}
+
+		if rsp.StatusCode != route.Response.StatusCode {
+			t.Fatalf("Expected code %d got %d", route.Response.StatusCode, rsp.StatusCode)
+		}
+
+		loc := rsp.Header.Get("Location")
+		if loc != route.Response.Header["Location"] {
+			t.Fatalf("Expected Location %s got %s", route.Response.Header["Location"], loc)
+		}
+	}
+}

--- a/micro/router/router_test.go
+++ b/micro/router/router_test.go
@@ -49,6 +49,20 @@ func TestRouter(t *testing.T) {
 			},
 			Weight: 1.0,
 		},
+		{
+			Request: Request{
+				Method: "GET",
+				Host:   l.Addr().String(),
+				Path:   "/foobar",
+			},
+			ProxyURL: URL{
+				Scheme: "http",
+				Host:   "www.foo.com",
+				Path:   "/",
+			},
+			Weight: 1.0,
+			Type:   "proxy",
+		},
 	}
 
 	apiConfig := map[string]interface{}{
@@ -96,6 +110,13 @@ func TestRouter(t *testing.T) {
 			} else {
 				t.Fatal(err)
 			}
+		}
+
+		if route.Type == "proxy" {
+			if rsp.StatusCode >= 400 {
+				t.Fatalf("Expected healthy response got %d", rsp.StatusCode)
+			}
+			continue
 		}
 
 		if rsp.StatusCode != route.Response.StatusCode {

--- a/micro/router/router_test.go
+++ b/micro/router/router_test.go
@@ -33,6 +33,7 @@ func TestRouter(t *testing.T) {
 					"Location": "http://example.com",
 				},
 			},
+			Weight: 1.0,
 		},
 		{
 			Request: Request{
@@ -46,6 +47,7 @@ func TestRouter(t *testing.T) {
 					"Location": "http://foo.bar.com",
 				},
 			},
+			Weight: 1.0,
 		},
 	}
 

--- a/micro/router/routes.go
+++ b/micro/router/routes.go
@@ -1,5 +1,11 @@
 package router
 
+import (
+	"math/rand"
+	"net/http"
+	"time"
+)
+
 // Routes is the config expected to be loaded
 type Routes struct {
 	Routes []Route `json:"routes"`
@@ -12,7 +18,8 @@ type Route struct {
 	Request  Request  `json:"request"`
 	Response Response `json:"response"`
 	Priority int      `json:"priority"` // 0 is highest. Used for ordering routes
-	// TODO: weight
+	// TODO: Weight
+	// TODO: Type: Proxy, Default
 }
 
 // Request describes the expected request and will
@@ -32,4 +39,61 @@ type Response struct {
 	StatusCode int               `json:"status_code"`
 	Header     map[string]string `json:"header"`
 	Body       []byte            `json:"body"`
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func (r Route) Match(req *http.Request) bool {
+	// bail on nil
+	if len(r.Request.Method) == 0 || len(r.Request.Path) == 0 {
+		return false
+	}
+
+	// just for ease
+	rq := r.Request
+
+	// first level match, quick and dirty
+	if (rq.Method == req.Method) && (rq.Host == req.Host) && (rq.Path == req.URL.Path) {
+		// skip
+	} else {
+		return false
+	}
+
+	// match headers
+	for k, v := range rq.Header {
+		// does it match?
+		if rv := req.Header.Get(k); rv != v {
+			return false
+		}
+	}
+
+	// match query
+	vals := req.URL.Query()
+	for k, v := range rq.Query {
+		// does it match?
+		if rv := vals.Get(k); rv != v {
+			return false
+		}
+	}
+
+	// we got a match!
+	return true
+}
+
+func (r Route) Write(w http.ResponseWriter, req *http.Request) {
+	// set headers
+	for k, v := range r.Response.Header {
+		w.Header().Set(k, v)
+	}
+	// set status code
+	w.WriteHeader(r.Response.StatusCode)
+
+	// set response
+	if len(r.Response.Body) > 0 {
+		w.Write(r.Response.Body)
+	} else {
+		w.Write([]byte(r.Response.Status))
+	}
 }

--- a/micro/router/routes.go
+++ b/micro/router/routes.go
@@ -25,7 +25,7 @@ type Route struct {
 // Request describes the expected request and will
 // attempt to match all fields specified
 type Request struct {
-	Method string            `json:"string"`
+	Method string            `json:"method"`
 	Header map[string]string `json:"header"`
 	Host   string            `json:"host"`
 	Path   string            `json:"path"`

--- a/micro/router/routes.go
+++ b/micro/router/routes.go
@@ -18,7 +18,7 @@ type Route struct {
 	Request  Request  `json:"request"`
 	Response Response `json:"response"`
 	Priority int      `json:"priority"` // 0 is highest. Used for ordering routes
-	// TODO: Weight
+	Weight   float64  `json:"weight"`   // percentage weight between 0 and 1.0
 	// TODO: Type: Proxy, Default
 }
 
@@ -76,6 +76,12 @@ func (r Route) Match(req *http.Request) bool {
 		if rv := vals.Get(k); rv != v {
 			return false
 		}
+	}
+
+	// Now weight it. If already set to 0.0 then return
+	// Otherwise rand.Float64
+	if r.Weight == 0.0 || r.Weight < rand.Float64() {
+		return false
 	}
 
 	// we got a match!

--- a/micro/router/routes.go
+++ b/micro/router/routes.go
@@ -1,0 +1,35 @@
+package router
+
+// Routes is the config expected to be loaded
+type Routes struct {
+	Routes []Route `json:"routes"`
+	// TODO: default route
+}
+
+// Route describes a single route which is matched
+// on Request and if so, will return the Response
+type Route struct {
+	Request  Request  `json:"request"`
+	Response Response `json:"response"`
+	Priority int      `json:"priority"` // 0 is highest. Used for ordering routes
+	// TODO: weight
+}
+
+// Request describes the expected request and will
+// attempt to match all fields specified
+type Request struct {
+	Method string            `json:"string"`
+	Header map[string]string `json:"header"`
+	Host   string            `json:"host"`
+	Path   string            `json:"path"`
+	Query  map[string]string `json:"query"`
+	// TODO: RemoteAddr, Body
+}
+
+// Response is put into the http.Response for a Request
+type Response struct {
+	Status     string            `json:"status"`
+	StatusCode int               `json:"status_code"`
+	Header     map[string]string `json:"header"`
+	Body       []byte            `json:"body"`
+}

--- a/micro/router/routes_test.go
+++ b/micro/router/routes_test.go
@@ -20,6 +20,7 @@ func TestRoutes(t *testing.T) {
 						Host:   "example.com",
 						Path:   "/",
 					},
+					Weight: 1.0,
 				},
 				{
 					Request: Request{
@@ -27,6 +28,7 @@ func TestRoutes(t *testing.T) {
 						Host:   "foo.com",
 						Path:   "/bar",
 					},
+					Weight: 1.0,
 				},
 			},
 			Req: &http.Request{
@@ -46,6 +48,7 @@ func TestRoutes(t *testing.T) {
 						Host:   "example.com",
 						Path:   "/",
 					},
+					Weight: 1.0,
 				},
 				{
 					Request: Request{
@@ -53,6 +56,7 @@ func TestRoutes(t *testing.T) {
 						Host:   "foo.com",
 						Path:   "/bar",
 					},
+					Weight: 1.0,
 				},
 			},
 			Req: &http.Request{
@@ -77,7 +81,7 @@ func TestRoutes(t *testing.T) {
 		}
 
 		if match != d.Match {
-			t.Fatal("Expected match %t got %t", d.Match, match)
+			t.Fatalf("Expected match %t got %t", d.Match, match)
 		}
 	}
 }

--- a/micro/router/routes_test.go
+++ b/micro/router/routes_test.go
@@ -1,0 +1,83 @@
+package router
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestRoutes(t *testing.T) {
+	testData := []struct {
+		Routes []Route
+		Req    *http.Request
+		Match  bool
+	}{
+		{
+			Routes: []Route{
+				{
+					Request: Request{
+						Method: "GET",
+						Host:   "example.com",
+						Path:   "/",
+					},
+				},
+				{
+					Request: Request{
+						Method: "POST",
+						Host:   "foo.com",
+						Path:   "/bar",
+					},
+				},
+			},
+			Req: &http.Request{
+				Method: "GET",
+				Host:   "example.com",
+				URL: &url.URL{
+					Path: "/",
+				},
+			},
+			Match: true,
+		},
+		{
+			Routes: []Route{
+				{
+					Request: Request{
+						Method: "GET",
+						Host:   "example.com",
+						Path:   "/",
+					},
+				},
+				{
+					Request: Request{
+						Method: "POST",
+						Host:   "foo.com",
+						Path:   "/bar",
+					},
+				},
+			},
+			Req: &http.Request{
+				Method: "POST",
+				Host:   "foo.com",
+				URL: &url.URL{
+					Path: "/bar",
+				},
+			},
+			Match: true,
+		},
+	}
+
+	for _, d := range testData {
+		var match bool
+
+		for _, r := range d.Routes {
+			if r.Match(d.Req) {
+				match = true
+				break
+			}
+		}
+
+		if match != d.Match {
+			t.Fatal("Expected match %t got %t", d.Match, match)
+		}
+	}
+}

--- a/micro/router/sort.go
+++ b/micro/router/sort.go
@@ -1,0 +1,17 @@
+package router
+
+type sortedRoutes struct {
+	routes Routes
+}
+
+func (s sortedRoutes) Len() int {
+	return len(s.routes.Routes)
+}
+
+func (s sortedRoutes) Less(i, j int) bool {
+	return s.routes.Routes[i].Priority < s.routes.Routes[j].Priority
+}
+
+func (s sortedRoutes) Swap(i, j int) {
+	s.routes.Routes[i], s.routes.Routes[j] = s.routes.Routes[j], s.routes.Routes[i]
+}

--- a/micro/router/sort_test.go
+++ b/micro/router/sort_test.go
@@ -1,0 +1,33 @@
+package router
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestRouterSort(t *testing.T) {
+	testData := []struct {
+		Routes []Route
+		Expect []int
+	}{
+		{
+			Routes: []Route{
+				{Priority: 5},
+				{Priority: 2},
+				{Priority: 3},
+				{Priority: 0},
+			},
+			Expect: []int{0, 2, 3, 5},
+		},
+	}
+
+	for _, d := range testData {
+		r := Routes{d.Routes}
+		sort.Sort(sortedRoutes{r})
+		for i, j := range d.Expect {
+			if r.Routes[i].Priority != j {
+				t.Fatal("Expected val %d got %d", j, r.Routes[i].Priority)
+			}
+		}
+	}
+}


### PR DESCRIPTION
The router plugin is a HTTP handler plugin for the Micro API which enables you to define routes via go-platform/config.