### PR TITLE
Fix etcdv3 bugs

### DIFF
--- a/registry/etcdv3/etcdv3.go
+++ b/registry/etcdv3/etcdv3.go
@@ -178,7 +178,7 @@ func (e *etcdv3Registry) GetService(name string) ([]*registry.Service, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), e.options.Timeout)
 	defer cancel()
 
-	rsp, err := e.client.Get(ctx, servicePath(name), clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortDescend))
+	rsp, err := e.client.Get(ctx, servicePath(name)+"/", clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortDescend))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When using the prefix parameter, the end of the key value should be added /.

For example, there are two services: rand  and randpro
/micro-registry/rand/rand-08c58afd-9cb1-11e6-9b83-64098063cd81
/micro-registry/randpro/randpro-345af32c-9cb1-11e6-8288-64098063cd81

When the rand service is acquired, it will also contain randpro.