### PR TITLE
Update grpc server to use new func signature...

### DIFF
--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -92,7 +92,7 @@ func (g *grpcServer) serve(l net.Listener) error {
 }
 
 func (g *grpcServer) accept(conn net.Conn) {
-	st, err := transport.NewServerTransport("http2", conn, 0, nil)
+	st, err := transport.NewServerTransport("http2", conn, nil)
 	if err != nil {
 		conn.Close()
 		return


### PR DESCRIPTION
for google.golang.org/grpc/transport.NewServerTransport. It
now takes a *ServerConfig struct instead of 2 params