### PR TITLE
fixed runtime error in go-plugins/examples/sync/consul

### DIFF
--- a/sync/consul/leader.go
+++ b/sync/consul/leader.go
@@ -34,7 +34,7 @@ type consulElected struct {
 
 func (c *consulLeader) Leader() (*registry.Node, error) {
 	kv, _, err := c.c.KV().Get(c.key, nil)
-	if err != nil {
+	if err != nil || kv == nil {
 		return nil, err
 	}
 	var node *registry.Node


### PR DESCRIPTION
I run go-plugins/examples/sync/consul/consul.go get **runtime error: invalid memory address or nil pointer dereference**,  below is output 

```
 ./consul 
[lock:2] attempting to acquire lock
[lock:0] attempting to acquire lock
[lock:1] attempting to acquire lock
[lock:1] acquired lock!
[lock:1] unlocking now
[lock:1] unlocked
[lock:2] acquired lock!
[lock:2] unlocking now
[lock:2] unlocked
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6411d6]

goroutine 28 [running]:
github.com/micro/go-plugins/sync/consul.(*consulLeader).Leader(0xc42014d080, 0x0, 0x0, 0x0)
	/usr/local/govendor/src/github.com/micro/go-plugins/sync/consul/leader.go:41 +0x136
main.leader(0x1, 0x7f3580, 0xc4200dd040)
	/root/test/go-plugins/examples/sync/consul/consul.go:49 +0x251
created by main.main
	/root/test/go-plugins/examples/sync/consul/consul.go:125 +0x4fb

```

and gdb output :

```
[Switching to Thread 0x7ffff67ee700 (LWP 13005)]
0x00000000006411d6 in github.com/micro/go-plugins/sync/consul.(*consulLeader).Leader (c=0xc420181ec0, ~r0=0x0, ~r1=...)
    at /usr/local/govendor/src/github.com/micro/go-plugins/sync/consul/leader.go:41
41		if err := json.Unmarshal(kv.Value, &node); err != nil {
(gdb) 
(gdb) list
36		kv, _, err := c.c.KV().Get(c.key, nil)
37		if err != nil {
38			return nil, err
39		}
40		var node *registry.Node
41		if err := json.Unmarshal(kv.Value, &node); err != nil {
42			return nil, err
43		}
44		return node, nil
45	}

```
I  fixed the Segmentation fault by add `kv == nil` to go-plugins\sync\consul\leader.go
```
func (c *consulLeader) Leader() (*registry.Node, error) {
	kv, _, err := c.c.KV().Get(c.key, nil)
	// if err != nil {
	if err != nil || kv == nil {
		return nil, err
	}
	var node *registry.Node
	if err := json.Unmarshal(kv.Value, &node); err != nil {
		return nil, err
	}
	return node, nil
}
```
output
```
./consul 
[lock:2] attempting to acquire lock
[lock:0] attempting to acquire lock
[lock:1] attempting to acquire lock
[lock:1] acquired lock!
[lock:1] unlocking now
[lock:1] unlocked
[lock:2] acquired lock!
[lock:2] unlocking now
[lock:2] unlocked
[leader:2] [status:0] attempting to elect self. current leader <nil>
[lock:0] acquired lock!
[leader:1] [status:0] attempting to elect self. current leader <nil>
[leader:0] [status:0] attempting to elect self. current leader <nil>
[leader:1] [status:0] elected as leader
[leader:1] [status:0] I'm leading son
[lock:0] unlocking now
[lock:0] unlocked
[leader:1] [status:2] I'm leading son
[leader:1] [status:2] I'm leading son
[leader:1] [status:2] I'm leading son
[leader:1] [status:2] current leader &{foo-1  0 map[]}
[leader:1] [status:2] resigning now
[leader:1] [status:0] resigned
[leader:0] [status:0] elected as leader
[leader:0] [status:0] I'm leading son
[leader:0] [status:2] I'm leading son
[leader:0] [status:2] I'm leading son
[leader:0] [status:2] I'm leading son

```


