### PR TITLE
Convert go-micro error to grpc code

### DIFF
--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/micro/go-micro/broker"
 	"github.com/micro/go-micro/cmd"
 	"github.com/micro/go-micro/codec"
+	microErrors "github.com/micro/go-micro/errors"
 	meta "github.com/micro/go-micro/metadata"
 	"github.com/micro/go-micro/registry"
 	"github.com/micro/go-micro/server"
@@ -362,6 +363,16 @@ func (g *grpcServer) processRequest(t transport.ServerTransport, stream *transpo
 			if err, ok := appErr.(*rpcError); ok {
 				statusCode = err.code
 				statusDesc = err.desc
+			} else if err, ok := appErr.(*microErrors.Error); ok {
+				switch err.Code {
+				case 404:
+					statusCode = codes.NotFound
+				case 401:
+					statusCode = codes.Unauthenticated
+				default:
+					statusCode = codes.Internal
+				}
+				statusDesc = err.Detail
 			} else {
 				statusCode = convertCode(appErr)
 				statusDesc = appErr.Error()


### PR DESCRIPTION
Maybe I am using go-micro in a wrong way, but here is an issue have.

Inside a grpc handler I use `errors` package from go-micro to return an error, like this:
```go
microErrors "github.com/micro/go-micro/errors"
....
func (t *SomeServer) GetObject(ctx context.Context, request *proto.GetObjectRequest, out *proto.Object) error {
   ...
   return microErrors.NotFound(GetObjectFailed_NoObjectFound, "not found")
```
It looks like you assume, that users will use `grpc.Error` (https://github.com/micro/go-plugins/blob/master/server/grpc/util.go#L228) which produces `rpcError`, however it makes the handler code grpc specific and not transport agnostic which is the point of go-micro. Probably.

Returned `microErrors.Error` error will always result in `InternalError` grpc status code from the client prospective, because if it is not of type `rpcError` you treat it as a generic error, not taking `Error.Code` into account.

So I added a conversion part to `grpc` plugin. It is a draft, does not cover all the errors. Just a POC if that's how it should work.