### PR TITLE
registry/etcdv3 get service from prevKv in EventTypeDelete

### DIFF
--- a/registry/etcdv3/etcdv3.go
+++ b/registry/etcdv3/etcdv3.go
@@ -183,10 +183,6 @@ func (e *etcdv3Registry) GetService(name string) ([]*registry.Service, error) {
 		return nil, err
 	}
 
-	if len(rsp.Kvs) == 0 {
-		return nil, registry.ErrNotFound
-	}
-
 	serviceMap := map[string]*registry.Service{}
 
 	for _, n := range rsp.Kvs {


### PR DESCRIPTION
If prev_kv is set, created watcher gets the previous KV before the event happens. If the previous KV is already compacted, nothing will be returned.

fix #108 

remove len(rsp.Kvs) check in GetService
fix GetService retrun err when  len(rsp.Kvs) == 0
