### PR TITLE
Fix when grpc.NewClient with Codec option will cause panic

### DIFF
--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -437,6 +437,7 @@ func (g *grpcClient) String() string {
 
 func newClient(opts ...client.Option) client.Client {
 	options := client.Options{
+		Codecs: make(map[string]codec.NewCodec),
 		CallOptions: client.CallOptions{
 			Backoff:        client.DefaultBackoff,
 			Retry:          client.DefaultRetry,


### PR DESCRIPTION
Travis CI already failed before this PR [Build #608](https://travis-ci.org/micro/go-plugins/builds/289931921)

grpc.NewClient( client.Codec(contentType, codec) )  
will cause panic : assignment to entry in nil map