### PR TITLE
Add grpc options for 3rd codec and a default bytesCodec for client

### DIFF
--- a/client/grpc/codec.go
+++ b/client/grpc/codec.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/micro/go-micro/codec"
@@ -12,11 +13,13 @@ import (
 
 type jsonCodec struct{}
 type protoCodec struct{}
+type bytesCodec struct{}
 
 var (
 	defaultGRPCCodecs = map[string]grpc.Codec{
 		"application/grpc+json":  jsonCodec{},
 		"application/grpc+proto": protoCodec{},
+		"application/grpc+bytes": bytesCodec{},
 	}
 
 	defaultRPCCodecs = map[string]codec.NewCodec{
@@ -38,6 +41,27 @@ func (protoCodec) Unmarshal(data []byte, v interface{}) error {
 
 func (protoCodec) String() string {
 	return "proto"
+}
+
+func (bytesCodec) Marshal(v interface{}) ([]byte, error) {
+	b, ok := v.(*[]byte)
+	if !ok {
+		return nil, fmt.Errorf("failed to marshal: %v is not type of *[]byte", v)
+	}
+	return *b, nil
+}
+
+func (bytesCodec) Unmarshal(data []byte, v interface{}) error {
+	b, ok := v.(*[]byte)
+	if !ok {
+		return fmt.Errorf("failed to unmarshal: %v is not type of *[]byte", v)
+	}
+	*b = data
+	return nil
+}
+
+func (bytesCodec) String() string {
+	return "bytes"
 }
 
 func (jsonCodec) Marshal(v interface{}) ([]byte, error) {

--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -135,6 +135,15 @@ func (g *grpcClient) stream(ctx context.Context, address string, req client.Requ
 }
 
 func (g *grpcClient) newGRPCCodec(contentType string) (grpc.Codec, error) {
+	codecs := make(map[string]grpc.Codec)
+	if g.opts.Context != nil {
+		if v := g.opts.Context.Value(codecsKey{}); v != nil {
+			codecs = v.(map[string]grpc.Codec)
+		}
+	}
+	if c, ok := codecs[contentType]; ok {
+		return c, nil
+	}
 	if c, ok := defaultGRPCCodecs[contentType]; ok {
 		return c, nil
 	}

--- a/client/grpc/options.go
+++ b/client/grpc/options.go
@@ -1,0 +1,25 @@
+// Package grpc provides a gRPC options
+package grpc
+
+import (
+	"github.com/micro/go-micro/client"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+type codecsKey struct{}
+
+// gRPC Codec to be used to encode/decode requests for a given content type
+func Codec(contentType string, c grpc.Codec) client.Option {
+	return func(o *client.Options) {
+		codecs := make(map[string]grpc.Codec)
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		if v := o.Context.Value(codecsKey{}); v != nil {
+			codecs = v.(map[string]grpc.Codec)
+		}
+		codecs[contentType] = c
+		o.Context = context.WithValue(o.Context, codecsKey{}, codecs)
+	}
+}

--- a/server/grpc/codec.go
+++ b/server/grpc/codec.go
@@ -12,12 +12,14 @@ import (
 
 type jsonCodec struct{}
 type protoCodec struct{}
+type bytesCodec struct{}
 
 var (
 	defaultGRPCCodecs = map[string]grpc.Codec{
 		"application/grpc":       protoCodec{},
 		"application/grpc+json":  jsonCodec{},
 		"application/grpc+proto": protoCodec{},
+		"application/grpc+bytes": protoCodec{},
 	}
 
 	defaultRPCCodecs = map[string]codec.NewCodec{

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -451,6 +451,15 @@ func (g *grpcServer) processStream(t transport.ServerTransport, stream *transpor
 }
 
 func (g *grpcServer) newGRPCCodec(contentType string) (grpc.Codec, error) {
+	codecs := make(map[string]grpc.Codec)
+	if g.opts.Context != nil {
+		if v := g.opts.Context.Value(codecsKey{}); v != nil {
+			codecs = v.(map[string]grpc.Codec)
+		}
+	}
+	if c, ok := codecs[contentType]; ok {
+		return c, nil
+	}
 	if c, ok := defaultGRPCCodecs[contentType]; ok {
 		return c, nil
 	}


### PR DESCRIPTION
Add grpc codec options for both client side and server side.

Add a default bytesCodec for grpc client. 
It's useful to transmit bytes of pb message from client to server without marshaling.
It can also receive bytes of pb message without unmarshaling.
Cause it's only a client codec, the server side req and resp are pb message as usual.