### PR TITLE
Minor fixes to the open tracing wrapper.

### DIFF
--- a/wrapper/trace/opentracing/opentracing.go
+++ b/wrapper/trace/opentracing/opentracing.go
@@ -7,6 +7,7 @@ import (
 	"github.com/micro/go-micro/client"
 	"github.com/micro/go-micro/metadata"
 	"github.com/micro/go-micro/server"
+	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 )
 

--- a/wrapper/trace/opentracing/opentracing.go
+++ b/wrapper/trace/opentracing/opentracing.go
@@ -7,7 +7,6 @@ import (
 	"github.com/micro/go-micro/client"
 	"github.com/micro/go-micro/metadata"
 	"github.com/micro/go-micro/server"
-	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 )
 
@@ -16,7 +15,7 @@ type otWrapper struct {
 	client.Client
 }
 
-func traceIntoContext(ctx context.Context, tracer opentracing.Tracer, name string) (context.Context, error) {
+func traceIntoContext(ctx context.Context, tracer opentracing.Tracer, name string) (context.Context, opentracing.Span, error) {
 	md, _ := metadata.FromContext(ctx)
 	var sp opentracing.Span
 	wireContext, err := tracer.Extract(opentracing.TextMap, opentracing.TextMapCarrier(md))
@@ -25,29 +24,31 @@ func traceIntoContext(ctx context.Context, tracer opentracing.Tracer, name strin
 	} else {
 		sp = tracer.StartSpan(name, opentracing.ChildOf(wireContext))
 	}
-	defer sp.Finish()
 	if err := sp.Tracer().Inject(sp.Context(), opentracing.TextMap, opentracing.TextMapCarrier(md)); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	ctx = opentracing.ContextWithSpan(ctx, sp)
 	ctx = metadata.NewContext(ctx, md)
-	return ctx, nil
+	return ctx, sp, nil
 }
 
 func (o *otWrapper) Call(ctx context.Context, req client.Request, rsp interface{}, opts ...client.CallOption) error {
 	name := fmt.Sprintf("%s.%s", req.Service(), req.Method())
-	ctx, err := traceIntoContext(ctx, o.ot, name)
+	ctx, span, err := traceIntoContext(ctx, o.ot, name)
 	if err != nil {
 		return err
 	}
+	defer span.Finish()
 	return o.Client.Call(ctx, req, rsp, opts...)
 }
 
 func (o *otWrapper) Publish(ctx context.Context, p client.Publication, opts ...client.PublishOption) error {
 	name := fmt.Sprintf("Pub to %s", p.Topic())
-	ctx, err := traceIntoContext(ctx, o.ot, name)
+	ctx, span, err := traceIntoContext(ctx, o.ot, name)
 	if err != nil {
 		return err
 	}
+	defer span.Finish()
 	return o.Client.Publish(ctx, p, opts...)
 }
 
@@ -63,10 +64,11 @@ func NewHandlerWrapper(ot opentracing.Tracer) server.HandlerWrapper {
 	return func(h server.HandlerFunc) server.HandlerFunc {
 		return func(ctx context.Context, req server.Request, rsp interface{}) error {
 			name := fmt.Sprintf("%s.%s", req.Service(), req.Method())
-			ctx, err := traceIntoContext(ctx, ot, name)
+			ctx, span, err := traceIntoContext(ctx, ot, name)
 			if err != nil {
 				return err
 			}
+			defer span.Finish()
 			return h(ctx, req, rsp)
 		}
 	}
@@ -77,10 +79,11 @@ func NewSubscriberWrapper(ot opentracing.Tracer) server.SubscriberWrapper {
 	return func(next server.SubscriberFunc) server.SubscriberFunc {
 		return func(ctx context.Context, msg server.Publication) error {
 			name := "Pub to " + msg.Topic()
-			ctx, err := traceIntoContext(ctx, ot, name)
+			ctx, span, err := traceIntoContext(ctx, ot, name)
 			if err != nil {
 				return err
 			}
+			defer span.Finish()
 			return next(ctx, msg)
 		}
 	}


### PR DESCRIPTION
No longer defering span.Finish() inside the traceIntoContext function, as this prematurely finishes the span, stopping the timer and preventing child spans.
Secondly, in order to allow the code in the wrapped functions to propagate and create sub-spans, we need to create a new context that contains the newly created span.