### PR TITLE
added additional nats options

### DIFF
--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -195,7 +195,6 @@ func NewBroker(opts ...broker.Option) broker.Broker {
 		maxPingOut:       DefaultNatsMaxPingOut,
 		reconnectBufSize: DefaultNatsReconnectBufSize,
 		allowReconnect:   DefaultNatsAllowReconnect,
-		closedHandler:    nil,
 	}
 
 	options := broker.Options{

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -15,7 +15,7 @@ type nbroker struct {
 	addrs []string
 	conn  *nats.Conn
 	opts  broker.Options
-	bopts *brokerOptions
+	nopts *natsOptions
 }
 
 type subscriber struct {
@@ -93,14 +93,22 @@ func (n *nbroker) Connect() error {
 	opts.Servers = n.addrs
 	opts.Secure = n.opts.Secure
 	opts.TLSConfig = n.opts.TLSConfig
-	opts.MaxReconnect = n.bopts.maxReconnect
-	opts.ReconnectWait = n.bopts.reconnectWait
-	opts.Timeout = n.bopts.timeout
-	opts.PingInterval = n.bopts.pingInterval
-	opts.MaxPingsOut = n.bopts.maxPingOut
-	opts.SubChanLen = n.bopts.maxChanLen
-	opts.ReconnectBufSize = n.bopts.reconnectBufSize
-	opts.Name = n.bopts.name
+	opts.MaxReconnect = n.nopts.maxReconnect
+	opts.ReconnectWait = n.nopts.reconnectWait
+	opts.Timeout = n.nopts.timeout
+	opts.AllowReconnect = n.nopts.allowReconnect
+	opts.PingInterval = n.nopts.pingInterval
+	opts.MaxPingsOut = n.nopts.maxPingOut
+	opts.SubChanLen = n.nopts.maxChanLen
+	opts.ReconnectBufSize = n.nopts.reconnectBufSize
+	opts.Name = n.nopts.name
+	opts.DisconnectedCB = n.nopts.disconnectHandler
+	opts.ClosedCB = n.nopts.closedHandler
+	opts.DiscoveredServersCB = n.nopts.discoveredServersHandler
+	opts.AsyncErrorCB = n.nopts.errorHandler
+	opts.User = n.nopts.username
+	opts.Password = n.nopts.password
+	opts.Token = n.nopts.token
 
 	// secure might not be set
 	if n.opts.TLSConfig != nil {
@@ -113,26 +121,6 @@ func (n *nbroker) Connect() error {
 	}
 
 	n.conn = c
-
-	if n.bopts.closedHandler != nil {
-		n.conn.SetClosedHandler(n.bopts.closedHandler)
-	}
-
-	if n.bopts.disconnectHandler != nil {
-		n.conn.SetDisconnectHandler(n.bopts.disconnectHandler)
-	}
-
-	if n.bopts.discoveredServersHandler != nil {
-		n.conn.SetDiscoveredServersHandler(n.bopts.discoveredServersHandler)
-	}
-
-	if n.bopts.reconnectHandler != nil {
-		n.conn.SetReconnectHandler(n.bopts.reconnectHandler)
-	}
-
-	if n.bopts.errorHandler != nil {
-		n.conn.SetErrorHandler(n.bopts.errorHandler)
-	}
 
 	return nil
 }
@@ -199,20 +187,21 @@ func (n *nbroker) String() string {
 
 func NewBroker(opts ...broker.Option) broker.Broker {
 
-	bopts := &brokerOptions{
-		maxReconnect:     DefaultMaxReconnect,
-		reconnectWait:    DefaultReconnectWait,
-		timeout:          DefaultTimeout,
-		pingInterval:     DefaultPingInterval,
-		maxPingOut:       DefaultMaxPingOut,
-		reconnectBufSize: DefaultReconnectBufSize,
+	nopts := &natsOptions{
+		maxReconnect:     DefaultNatsMaxReconnect,
+		reconnectWait:    DefaultNatsReconnectWait,
+		timeout:          DefaultNatsTimeout,
+		pingInterval:     DefaultNatsPingInterval,
+		maxPingOut:       DefaultNatsMaxPingOut,
+		reconnectBufSize: DefaultNatsReconnectBufSize,
+		allowReconnect:   DefaultNatsAllowReconnect,
 		closedHandler:    nil,
 	}
 
 	options := broker.Options{
 		// Default codec
 		Codec:   json.NewCodec(),
-		Context: context.WithValue(context.Background(), optionsKey, bopts),
+		Context: context.WithValue(context.Background(), optionsKey, nopts),
 	}
 
 	for _, o := range opts {
@@ -222,6 +211,6 @@ func NewBroker(opts ...broker.Option) broker.Broker {
 	return &nbroker{
 		addrs: setAddrs(options.Addrs),
 		opts:  options,
-		bopts: bopts,
+		nopts: nopts,
 	}
 }

--- a/broker/nats/options.go
+++ b/broker/nats/options.go
@@ -1,0 +1,131 @@
+package nats
+
+import (
+	"time"
+
+	"github.com/micro/go-micro/broker"
+	"github.com/nats-io/nats"
+)
+
+// default NATS client values
+var (
+	DefaultMaxReconnect     = 60
+	DefaultReconnectWait    = 2 * time.Second
+	DefaultTimeout          = 2 * time.Second
+	DefaultPingInterval     = 2 * time.Minute
+	DefaultMaxPingOut       = 2
+	DefaultMaxChanLen       = 8192            // 8k
+	DefaultReconnectBufSize = 8 * 1024 * 1024 // 8MB
+
+	optionsKey = optionsKeyType{}
+)
+
+// brokerOptions contains NATS specific options
+type brokerOptions struct {
+	maxReconnect             int
+	name                     string
+	reconnectWait            time.Duration
+	timeout                  time.Duration
+	pingInterval             time.Duration
+	maxPingOut               int
+	maxChanLen               int
+	reconnectBufSize         int
+	closedHandler            func(*nats.Conn)
+	disconnectHandler        func(*nats.Conn)
+	discoveredServersHandler func(*nats.Conn)
+	reconnectHandler         func(*nats.Conn)
+	errorHandler             func(*nats.Conn, *nats.Subscription, error)
+}
+
+type optionsKeyType struct{}
+
+func MaxReconnect(n int) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.maxReconnect = n
+	}
+}
+
+func ReconnectWait(d time.Duration) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.reconnectWait = d
+	}
+}
+
+func Timeout(d time.Duration) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.timeout = d
+	}
+}
+
+func PingInterval(d time.Duration) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.pingInterval = d
+	}
+}
+
+func MaxPingOut(n int) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.maxPingOut = n
+	}
+}
+
+func MaxChanLen(n int) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.maxChanLen = n
+	}
+}
+
+func ReconnectBufSize(n int) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.reconnectBufSize = n
+	}
+}
+
+func ClosedHandler(cb nats.ConnHandler) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.closedHandler = cb
+	}
+}
+
+func DisconnectHandler(cb nats.ConnHandler) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.disconnectHandler = cb
+	}
+}
+
+func DiscoveredServersHandler(cb nats.ConnHandler) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.discoveredServersHandler = cb
+	}
+}
+
+func ReconnectHandler(cb nats.ConnHandler) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.reconnectHandler = cb
+	}
+}
+
+func ErrorHandler(cb nats.ErrHandler) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.errorHandler = cb
+	}
+}
+
+func Name(s string) broker.Option {
+	return func(o *broker.Options) {
+		bo := o.Context.Value(optionsKey).(*brokerOptions)
+		bo.name = s
+	}
+}


### PR DESCRIPTION
Hi, 

I added more nats specific options for the broker. They can be passed in as functional options (via options.Context).

I wasn't able to create meaningful unit tests since the `NewBroker(opts ...broker.Option) broker.Broker` does only return an interface, hiding access to the `nats.Conn` instance.

I also replaced `opts := nats.DefaultOptions` with `opts := nats.GetDefaultOptions()` since the first one has been deprecated.

If this PR gets accepted I would like to submit the same PR for the nats plugin for Registry and Transport.