### PR TITLE
add option to inject nats.Options in nats Broker

### DIFF
--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -2,8 +2,9 @@
 package nats
 
 import (
-	"context"
 	"strings"
+
+	"golang.org/x/net/context"
 
 	"github.com/micro/go-micro/broker"
 	"github.com/micro/go-micro/broker/codec/json"

--- a/broker/nats/nats_test.go
+++ b/broker/nats/nats_test.go
@@ -67,7 +67,7 @@ func TestInitAddrs(t *testing.T) {
 			case "natsOptionConstructor":
 				nopts := nats.GetDefaultOptions()
 				nopts.Servers = addrs
-				br = NewBroker(NatsOptions(nopts))
+				br = NewBroker(Options(nopts))
 				br.Init()
 			case "default":
 				br = NewBroker()

--- a/broker/nats/options.go
+++ b/broker/nats/options.go
@@ -1,27 +1,21 @@
 package nats
 
 import (
+	"context"
+
 	"github.com/micro/go-micro/broker"
 	"github.com/nats-io/nats"
 )
 
-var (
-	DefaultNatsOptions = nats.GetDefaultOptions()
+type optionsKey struct{}
 
-	optionsKey = optionsKeyType{}
-)
-
-type optionsKeyType struct{}
-
-type brokerOptions struct {
-	natsOptions nats.Options
-}
-
-// NatsOptions allow to inject a nats.Options struct for configuring
+// Options allow to inject a nats.Options struct for configuring
 // the nats connection
-func NatsOptions(nopts nats.Options) broker.Option {
+func Options(nopts nats.Options) broker.Option {
 	return func(o *broker.Options) {
-		no := o.Context.Value(optionsKey).(*brokerOptions)
-		no.natsOptions = nopts
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, optionsKey{}, nopts)
 	}
 }

--- a/broker/nats/options.go
+++ b/broker/nats/options.go
@@ -1,7 +1,7 @@
 package nats
 
 import (
-	"context"
+	"golang.org/x/net/context"
 
 	"github.com/micro/go-micro/broker"
 	"github.com/nats-io/nats"

--- a/broker/nats/options.go
+++ b/broker/nats/options.go
@@ -1,0 +1,27 @@
+package nats
+
+import (
+	"github.com/micro/go-micro/broker"
+	"github.com/nats-io/nats"
+)
+
+var (
+	DefaultNatsOptions = nats.GetDefaultOptions()
+
+	optionsKey = optionsKeyType{}
+)
+
+type optionsKeyType struct{}
+
+type brokerOptions struct {
+	natsOptions nats.Options
+}
+
+// NatsOptions allow to inject a nats.Options struct for configuring
+// the nats connection
+func NatsOptions(nopts nats.Options) broker.Option {
+	return func(o *broker.Options) {
+		no := o.Context.Value(optionsKey).(*brokerOptions)
+		no.natsOptions = nopts
+	}
+}


### PR DESCRIPTION
Hi, 

as discussed on Slack I've re-written the original [PR-136](https://github.com/micro/go-plugins/pull/136). This PR allows to inject a `nats.Options` as `broker.Option`.

I've also extended the existing test to cover the newly added functionality.

If this PR is ok for you, I would add a similar one to nats Registry and Transport.