### PR TITLE
add option to inject nats.Options in nats Registry

### DIFF
--- a/registry/nats/options.go
+++ b/registry/nats/options.go
@@ -2,12 +2,25 @@ package nats
 
 import (
 	"github.com/micro/go-micro/registry"
+	"github.com/nats-io/nats"
 	"golang.org/x/net/context"
 )
 
 type contextQuorumKey struct{}
+type optionsKeyType struct{}
 
-var DefaultQuorum = 0
+var (
+	DefaultQuorum      = 0
+	DefaultNatsOptions = nats.GetDefaultOptions()
+
+	optionsKey = optionsKeyType{}
+)
+
+type registryOptions struct {
+	natsOptions nats.Options
+	queryTopic  string
+	watchTopic  string
+}
 
 func Quorum(n int) registry.Option {
 	return func(o *registry.Options) {
@@ -25,5 +38,35 @@ func getQuorum(o registry.Options) int {
 		return v
 	} else {
 		return DefaultQuorum
+	}
+}
+
+// NatsOptions allow to inject a nats.Options struct for configuring
+// the nats connection
+func NatsOptions(nopts nats.Options) registry.Option {
+	return func(o *registry.Options) {
+		no := o.Context.Value(optionsKey).(*registryOptions)
+		no.natsOptions = nopts
+	}
+}
+
+// QueryTopic allows to set a custom nats topic on which service registries
+// query (survey) other services. All registries listen on this topic and
+// then respond to the query message.
+func QueryTopic(s string) registry.Option {
+	return func(o *registry.Options) {
+		no := o.Context.Value(optionsKey).(*registryOptions)
+		no.queryTopic = s
+	}
+}
+
+// WatchTopic allows to set a custom nats topic on which registries broadcast
+// changes (e.g. when services are added, updated or removed). Since we don't
+// have a central registry service, each service typically broadcasts in a
+// determined frequency on this topic.
+func WatchTopic(s string) registry.Option {
+	return func(o *registry.Options) {
+		no := o.Context.Value(optionsKey).(*registryOptions)
+		no.watchTopic = s
 	}
 }

--- a/registry/nats/options_test.go
+++ b/registry/nats/options_test.go
@@ -58,7 +58,7 @@ func TestInitAddrs(t *testing.T) {
 			case "natsOption":
 				nopts := nats.GetDefaultOptions()
 				nopts.Servers = addrs
-				reg = NewRegistry(NatsOptions(nopts))
+				reg = NewRegistry(Options(nopts))
 			case "default":
 				reg = NewRegistry()
 			}

--- a/registry/nats/options_test.go
+++ b/registry/nats/options_test.go
@@ -1,0 +1,163 @@
+package nats
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-log/log"
+	"github.com/micro/go-micro/registry"
+	"github.com/nats-io/nats"
+)
+
+var addrTestCases = []struct {
+	name        string
+	description string
+	addrs       map[string]string // expected address : set address
+}{
+	{
+		"registryOption",
+		"set registry addresses through a registry.Option in constructor",
+		map[string]string{
+			"nats://192.168.10.1:5222": "192.168.10.1:5222",
+			"nats://10.20.10.0:4222":   "10.20.10.0:4222"},
+	},
+	{
+		"natsOption",
+		"set registry addresses through the nats.Option in constructor",
+		map[string]string{
+			"nats://192.168.10.1:5222": "192.168.10.1:5222",
+			"nats://10.20.10.0:4222":   "10.20.10.0:4222"},
+	},
+	{
+		"default",
+		"check if default Address is set correctly",
+		map[string]string{
+			"nats://localhost:4222": ""},
+	},
+}
+
+func TestInitAddrs(t *testing.T) {
+
+	for _, tc := range addrTestCases {
+		t.Run(fmt.Sprintf("%s: %s", tc.name, tc.description), func(t *testing.T) {
+
+			var reg registry.Registry
+			var addrs []string
+
+			for _, addr := range tc.addrs {
+				addrs = append(addrs, addr)
+			}
+
+			switch tc.name {
+			case "registryOption":
+				// we know that there are just two addrs in the dict
+				reg = NewRegistry(registry.Addrs(addrs[0], addrs[1]))
+			case "natsOption":
+				nopts := nats.GetDefaultOptions()
+				nopts.Servers = addrs
+				reg = NewRegistry(NatsOptions(nopts))
+			case "default":
+				reg = NewRegistry()
+			}
+
+			// if err := reg.Register(dummyService); err != nil {
+			// 	t.Fatal(err)
+			// }
+
+			natsRegistry, ok := reg.(*natsRegistry)
+			if !ok {
+				t.Fatal("Expected registry to be of types *natsRegistry")
+			}
+			// check if the same amount of addrs we set has actually been set
+			if len(natsRegistry.addrs) != len(tc.addrs) {
+				t.Errorf("Expected Addr count = %d, Actual Addr count = %d",
+					len(natsRegistry.addrs), len(tc.addrs))
+			}
+
+			for _, addr := range natsRegistry.addrs {
+				_, ok := tc.addrs[addr]
+				if !ok {
+					t.Errorf("Expected '%s' has not been set", addr)
+				}
+			}
+		})
+
+	}
+}
+
+func TestWatchQueryTopic(t *testing.T) {
+
+	natsURL := os.Getenv("NATS_URL")
+	if natsURL == "" {
+		log.Logf("NATS_URL is undefined - skipping tests")
+		return
+	}
+
+	watchTopic := "custom.test.watch"
+	queryTopic := "custom.test.query"
+	wt := WatchTopic(watchTopic)
+	qt := QueryTopic(queryTopic)
+
+	// connect to NATS and subscribe to the Watch & Query topics where the
+	// registry will publish a msg
+	nopts := nats.GetDefaultOptions()
+	nopts.Servers = setAddrs([]string{natsURL})
+	conn, err := nopts.Connect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	okCh := make(chan struct{})
+
+	// Wait until we have received something on both topics
+	go func() {
+		wg.Wait()
+		close(okCh)
+	}()
+
+	// handler just calls wg.Done()
+	rcvdHdlr := func(m *nats.Msg) {
+		wg.Done()
+	}
+
+	_, err = conn.Subscribe(queryTopic, rcvdHdlr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = conn.Subscribe(watchTopic, rcvdHdlr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dummyService := &registry.Service{
+		Name:    "TestInitAddr",
+		Version: "1.0.0",
+	}
+
+	reg := NewRegistry(qt, wt, registry.Addrs(natsURL))
+
+	// trigger registry to send out message on watchTopic
+	if err := reg.Register(dummyService); err != nil {
+		t.Fatal(err)
+	}
+
+	// trigger registry to send out message on queryTopic
+	if _, err := reg.ListServices(); err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure that we received something on tc.topic
+	select {
+	case <-okCh:
+		// fine - we received on both topics a message from the registry
+	case <-time.After(time.Millisecond * 200):
+		t.Fatal("timeout - no data received on watch topic")
+	}
+}


### PR DESCRIPTION
Hi, 

in reference to our discussion on Slack, [PR-136](https://github.com/micro/go-plugins/pull/136) and [PR-138](https://github.com/micro/go-plugins/pull/138) I've written this PR which allows to inject nats.Options as registry.Option. 

I incorporates also 3 additional changes: 
- in the method`query(s string, quorum int)` there is a `conn.Subscription`. It's cbHandler times out after a fixed duration set by `DefaultTimeout`. IMHO the timeout should be made changeable and set to `registry.Option.Timeout`.
- a custom WatchTopic can be injected as a `registry.Option`
- a custom QueryTopic can be injected as a `registry.Option`

the custom WatchTopic and QueryTopic are needed to separate two or more groups of services when using the same broker.

I've added unit tests which cover the added code.