### PR TITLE
add option to inject nats.Options in nats Transport

### DIFF
--- a/transport/nats/nats.go
+++ b/transport/nats/nats.go
@@ -2,6 +2,7 @@
 package nats
 
 import (
+	"context"
 	"errors"
 	"io"
 	"strings"
@@ -17,6 +18,7 @@ import (
 type ntport struct {
 	addrs []string
 	opts  transport.Options
+	nopts nats.Options
 }
 
 type ntportClient struct {
@@ -57,6 +59,23 @@ var (
 
 func init() {
 	cmd.DefaultTransports["nats"] = NewTransport
+}
+
+func setAddrs(addrs []string) []string {
+	var cAddrs []string
+	for _, addr := range addrs {
+		if len(addr) == 0 {
+			continue
+		}
+		if !strings.HasPrefix(addr, "nats://") {
+			addr = "nats://" + addr
+		}
+		cAddrs = append(cAddrs, addr)
+	}
+	if len(cAddrs) == 0 {
+		cAddrs = []string{nats.DefaultURL}
+	}
+	return cAddrs
 }
 
 func (n *ntportClient) Send(m *transport.Message) error {
@@ -278,7 +297,7 @@ func (n *ntport) Dial(addr string, dialOpts ...transport.DialOption) (transport.
 		o(&dopts)
 	}
 
-	opts := nats.DefaultOptions
+	opts := n.nopts
 	opts.Servers = n.addrs
 	opts.Secure = n.opts.Secure
 	opts.TLSConfig = n.opts.TLSConfig
@@ -339,34 +358,44 @@ func (n *ntport) String() string {
 }
 
 func NewTransport(opts ...transport.Option) transport.Transport {
+
+	trOpts := &transportOptions{
+		natsOptions: DefaultNatsOptions,
+	}
+
 	options := transport.Options{
 		// Default codec
 		Codec:   json.NewCodec(),
 		Timeout: DefaultTimeout,
+		Context: context.WithValue(context.Background(), optionsKey, trOpts),
 	}
 
 	for _, o := range opts {
 		o(&options)
 	}
 
-	var cAddrs []string
-
-	for _, addr := range options.Addrs {
-		if len(addr) == 0 {
-			continue
-		}
-		if !strings.HasPrefix(addr, "nats://") {
-			addr = "nats://" + addr
-		}
-		cAddrs = append(cAddrs, addr)
+	// transport.Options have higher priority than nats.Options
+	// only if Addrs, Secure or TLSConfig were not set through a transport.Option
+	// we read them from nats.Option
+	if len(options.Addrs) == 0 {
+		options.Addrs = trOpts.natsOptions.Servers
 	}
 
-	if len(cAddrs) == 0 {
-		cAddrs = []string{nats.DefaultURL}
+	if !options.Secure {
+		options.Secure = trOpts.natsOptions.Secure
 	}
+
+	if options.TLSConfig == nil {
+		options.TLSConfig = trOpts.natsOptions.TLSConfig
+	}
+
+	// check & add nats:// prefix (this makes also sure that the addresses
+	// stored in natsRegistry.addrs and options.Addrs are identical)
+	options.Addrs = setAddrs(options.Addrs)
 
 	return &ntport{
-		addrs: cAddrs,
+		addrs: options.Addrs,
 		opts:  options,
+		nopts: trOpts.natsOptions,
 	}
 }

--- a/transport/nats/nats.go
+++ b/transport/nats/nats.go
@@ -329,7 +329,7 @@ func (n *ntport) Dial(addr string, dialOpts ...transport.DialOption) (transport.
 }
 
 func (n *ntport) Listen(addr string, listenOpts ...transport.ListenOption) (transport.Listener, error) {
-	opts := nats.DefaultOptions
+	opts := n.nopts
 	opts.Servers = n.addrs
 	opts.Secure = n.opts.Secure
 	opts.TLSConfig = n.opts.TLSConfig

--- a/transport/nats/nats_test.go
+++ b/transport/nats/nats_test.go
@@ -1,0 +1,81 @@
+package nats
+
+import (
+	"testing"
+
+	"github.com/micro/go-micro/transport"
+	"github.com/nats-io/nats"
+)
+
+var addrTestCases = []struct {
+	name        string
+	description string
+	addrs       map[string]string // expected address : set address
+}{
+	{
+		"transportOption",
+		"set broker addresses through a transport.Option",
+		map[string]string{
+			"nats://192.168.10.1:5222": "192.168.10.1:5222",
+			"nats://10.20.10.0:4222":   "10.20.10.0:4222"},
+	},
+	{
+		"natsOption",
+		"set broker addresses through the nats.Option",
+		map[string]string{
+			"nats://192.168.10.1:5222": "192.168.10.1:5222",
+			"nats://10.20.10.0:4222":   "10.20.10.0:4222"},
+	},
+	{
+		"default",
+		"check if default Address is set correctly",
+		map[string]string{
+			"nats://localhost:4222": ""},
+	},
+}
+
+// This test will check if options (here nats addresses) set through either
+// transport.Option or via nats.Option are successfully set.
+func TestInitAddrs(t *testing.T) {
+
+	for _, tc := range addrTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			var tr transport.Transport
+			var addrs []string
+
+			for _, addr := range tc.addrs {
+				addrs = append(addrs, addr)
+			}
+
+			switch tc.name {
+			case "transportOption":
+				// we know that there are just two addrs in the dict
+				tr = NewTransport(transport.Addrs(addrs[0], addrs[1]))
+			case "natsOption":
+				nopts := nats.GetDefaultOptions()
+				nopts.Servers = addrs
+				tr = NewTransport(NatsOptions(nopts))
+			case "default":
+				tr = NewTransport()
+			}
+
+			ntport, ok := tr.(*ntport)
+			if !ok {
+				t.Fatal("Expected broker to be of types *nbroker")
+			}
+			// check if the same amount of addrs we set has actually been set
+			if len(ntport.addrs) != len(tc.addrs) {
+				t.Errorf("Expected Addr count = %d, Actual Addr count = %d",
+					len(ntport.addrs), len(tc.addrs))
+			}
+
+			for _, addr := range ntport.addrs {
+				_, ok := tc.addrs[addr]
+				if !ok {
+					t.Errorf("Expected '%s' has not been set", addr)
+				}
+			}
+		})
+	}
+}

--- a/transport/nats/nats_test.go
+++ b/transport/nats/nats_test.go
@@ -55,7 +55,7 @@ func TestInitAddrs(t *testing.T) {
 			case "natsOption":
 				nopts := nats.GetDefaultOptions()
 				nopts.Servers = addrs
-				tr = NewTransport(NatsOptions(nopts))
+				tr = NewTransport(Options(nopts))
 			case "default":
 				tr = NewTransport()
 			}

--- a/transport/nats/options.go
+++ b/transport/nats/options.go
@@ -1,27 +1,21 @@
 package nats
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/micro/go-micro/transport"
 	"github.com/nats-io/nats"
 )
 
-var (
-	DefaultNatsOptions = nats.GetDefaultOptions()
+type optionsKey struct{}
 
-	optionsKey = optionsKeyType{}
-)
-
-type optionsKeyType struct{}
-
-type transportOptions struct {
-	natsOptions nats.Options
-}
-
-// NatsOptions allow to inject a nats.Options struct for configuring
+// Options allow to inject a nats.Options struct for configuring
 // the nats connection
-func NatsOptions(nopts nats.Options) transport.Option {
+func Options(nopts nats.Options) transport.Option {
 	return func(o *transport.Options) {
-		no := o.Context.Value(optionsKey).(*transportOptions)
-		no.natsOptions = nopts
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, optionsKey{}, nopts)
 	}
 }

--- a/transport/nats/options.go
+++ b/transport/nats/options.go
@@ -1,0 +1,27 @@
+package nats
+
+import (
+	"github.com/micro/go-micro/transport"
+	"github.com/nats-io/nats"
+)
+
+var (
+	DefaultNatsOptions = nats.GetDefaultOptions()
+
+	optionsKey = optionsKeyType{}
+)
+
+type optionsKeyType struct{}
+
+type transportOptions struct {
+	natsOptions nats.Options
+}
+
+// NatsOptions allow to inject a nats.Options struct for configuring
+// the nats connection
+func NatsOptions(nopts nats.Options) transport.Option {
+	return func(o *transport.Options) {
+		no := o.Context.Value(optionsKey).(*transportOptions)
+		no.natsOptions = nopts
+	}
+}


### PR DESCRIPTION
Hi,

in reference to our discussion on Slack, [PR-136](https://github.com/micro/go-plugins/pull/136), [PR-138](https://github.com/micro/go-plugins/pull/138) and [PR-139](https://github.com/micro/go-plugins/pull/139). I've written this PR which allows to inject nats.Options as transport.Option.

In the constructor function `NewTransport()` I've taken cut out the code which checks if the nats address actually has the `nats://` prefix and put it into the function `setAddrs()`. This is now also consistent with the nats Broker and Registry.

I've added unit tests which cover the added code.