### PR TITLE
Handle failed connections to statsd server

### DIFF
--- a/metrics/statsd/statsd.go
+++ b/metrics/statsd/statsd.go
@@ -113,7 +113,25 @@ func (s *statsd) run() {
 	t := time.NewTicker(s.opts.BatchInterval)
 	buf := bytes.NewBuffer(nil)
 
-	conn, _ := net.DialTimeout("udp", s.opts.Collectors[0], time.Second)
+	var conn net.Conn
+
+	for {
+		for _, collector := range s.opts.Collectors {
+			var err error
+
+			conn, err = net.DialTimeout("udp", collector, 1*time.Second)
+			if err == nil {
+				break
+			}
+		}
+
+		if conn != nil {
+			break
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
 	defer conn.Close()
 
 	for {


### PR DESCRIPTION
I was getting some panics on calls to the `conn` handle when `net.DialTimeout` returned an error, thus also returning `nil` for the `conn` handle. This fix continues to loop through the list of provided statsd server addresses until a successful connection is made before entering into the long-running for-loop that pushes metrics to statsd.

It may or may not be worthwhile to 1) use a back-off approach, and/or 2) only try a certain amount of times before returning from the `run` function altogether.