### PR TITLE
Updated required RBAC ClusterRole verbs to include `watch`

### DIFF
--- a/registry/kubernetes/README.md
+++ b/registry/kubernetes/README.md
@@ -30,6 +30,7 @@ rules:
   verbs:
   - list
   - patch
+  - watch
 ```
 
 ```


### PR DESCRIPTION
This bit me in the ass for a while... especially since I wasn't seeing
the issue locally in minikube. Turns out minikube doesn't enable RBAC by
default! Aargh.