### PR TITLE
Updated SQS broker

### DIFF
--- a/broker/sqs/sqs.go
+++ b/broker/sqs/sqs.go
@@ -196,6 +196,13 @@ func (b *sqsBroker) Connect() error {
 	return nil
 }
 
+// ConnectWithSQSClient receives an instantiated instance of an SQS client and sets that as the client
+// used in SQS requests
+func (b *sqsBroker) ConnectWithSQSClient(svc *sqs.SQS) error {
+	b.svc = svc
+	return nil
+}
+
 // Disconnect does nothing as there's no live connection to terminate
 func (b *sqsBroker) Disconnect() error {
 	return nil

--- a/broker/sqs/sqs.go
+++ b/broker/sqs/sqs.go
@@ -24,7 +24,6 @@ const (
 
 // Amazon SQS Broker
 type sqsBroker struct {
-	session *session.Session
 	svc     *sqs.SQS
 	options broker.Options
 }
@@ -191,7 +190,6 @@ func (b *sqsBroker) Connect() error {
 
 	svc := sqs.New(sess)
 	b.svc = svc
-	b.session = sess
 
 	return nil
 }


### PR DESCRIPTION
This PR has two changes:

1. Added `ConnectWithSQSClient` method which receives an instantiated SQS client (perhaps configured with XRay or other configuration options)
2. Removes the `session` property on `sqsBroker` as it's not used by anything