### PR TITLE
SQS broker updates

### DIFF
--- a/broker/sqs/options.go
+++ b/broker/sqs/options.go
@@ -3,8 +3,10 @@ package sqs
 import (
 	"github.com/micro/go-micro/broker"
 	"golang.org/x/net/context"
+	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
+type sqsClient struct {}
 type dedupFunctionKey struct{}
 type groupIdFunctionKey struct{}
 type maxMessagesKey struct{}
@@ -65,5 +67,15 @@ func WaitTimeSeconds(seconds int64) broker.SubscribeOption {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, waitTimeSecondsKey{}, seconds)
+	}
+}
+
+// SetSQSClient receives an instantiated instance of an SQS client which is used instead of initialising a new client
+func SetSQSClient(svc *sqs.SQS) broker.Option {
+	return func(o *broker.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, sqsClient{}, svc)
 	}
 }

--- a/broker/sqs/options.go
+++ b/broker/sqs/options.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
-type sqsClient struct {}
+type sqsClientKey struct {}
 type dedupFunctionKey struct{}
 type groupIdFunctionKey struct{}
 type maxMessagesKey struct{}
@@ -71,11 +71,11 @@ func WaitTimeSeconds(seconds int64) broker.SubscribeOption {
 }
 
 // SetSQSClient receives an instantiated instance of an SQS client which is used instead of initialising a new client
-func SetSQSClient(svc *sqs.SQS) broker.Option {
+func SetSQSClient(SQSClient *sqs.SQS) broker.Option {
 	return func(o *broker.Options) {
 		if o.Context == nil {
 			o.Context = context.Background()
 		}
-		o.Context = context.WithValue(o.Context, sqsClient{}, svc)
+		o.Context = context.WithValue(o.Context, sqsClientKey{}, SQSClient)
 	}
 }

--- a/broker/sqs/sqs.go
+++ b/broker/sqs/sqs.go
@@ -24,7 +24,6 @@ const (
 
 // Amazon SQS Broker
 type sqsBroker struct {
-	session *session.Session
 	svc     *sqs.SQS
 	options broker.Options
 }
@@ -191,7 +190,6 @@ func (b *sqsBroker) Connect() error {
 
 	svc := sqs.New(sess)
 	b.svc = svc
-	b.session = sess
 
 	return nil
 }

--- a/broker/sqs/sqs.go
+++ b/broker/sqs/sqs.go
@@ -184,6 +184,11 @@ func (b *sqsBroker) Address() string {
 
 func (b *sqsBroker) Connect() error {
 
+	if svc := b.getSQSClient(); svc != nil {
+		b.svc = svc
+		return nil
+	}
+
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
@@ -300,6 +305,15 @@ func buildMessageHeader(attribs map[string]*sqs.MessageAttributeValue) map[strin
 		res[k] = *v.StringValue
 	}
 	return res
+}
+
+func (b *sqsBroker) getSQSClient() *sqs.SQS {
+	raw := b.options.Context.Value(sqsClient{})
+	if raw != nil {
+		s := raw.(*sqs.SQS)
+		return s
+	}
+	return nil
 }
 
 func (b *sqsBroker) generateGroupID(m *broker.Message) *string {

--- a/broker/sqs/sqs.go
+++ b/broker/sqs/sqs.go
@@ -308,7 +308,7 @@ func buildMessageHeader(attribs map[string]*sqs.MessageAttributeValue) map[strin
 }
 
 func (b *sqsBroker) getSQSClient() *sqs.SQS {
-	raw := b.options.Context.Value(sqsClient{})
+	raw := b.options.Context.Value(sqsClientKey{})
 	if raw != nil {
 		s := raw.(*sqs.SQS)
 		return s


### PR DESCRIPTION
This PR has two changes:

1. Removes unused session variable
2. Adds a new broker option to set an instantiated SQS client which will be used instead of creating a new client with shared config state