### PR TITLE
support shared address space using grpc

### DIFF
--- a/server/grpc/extractor.go
+++ b/server/grpc/extractor.go
@@ -14,7 +14,7 @@ var (
 )
 
 func init() {
-	for _, b := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"} {
+	for _, b := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10"} {
 		if _, block, err := net.ParseCIDR(b); err == nil {
 			privateBlocks = append(privateBlocks, block)
 		}


### PR DESCRIPTION
added "100.64.0.0/10" to grpc private addresses

Required to support "micro/kubernetes" on shared address space