### PR TITLE
move duplicated extractAddress func to micro/misc/lib/addr

### DIFF
--- a/server/grpc/extractor.go
+++ b/server/grpc/extractor.go
@@ -2,24 +2,11 @@ package grpc
 
 import (
 	"fmt"
-	"net"
 	"reflect"
 	"strings"
 
 	"github.com/micro/go-micro/registry"
 )
-
-var (
-	privateBlocks []*net.IPNet
-)
-
-func init() {
-	for _, b := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10"} {
-		if _, block, err := net.ParseCIDR(b); err == nil {
-			privateBlocks = append(privateBlocks, block)
-		}
-	}
-}
 
 func extractValue(v reflect.Type, d int) *registry.Value {
 	if d == 3 {
@@ -127,56 +114,4 @@ func extractSubValue(typ reflect.Type) *registry.Value {
 		return nil
 	}
 	return extractValue(reqType, 0)
-}
-
-func extractAddress(addr string) (string, error) {
-	if len(addr) > 0 && (addr != "0.0.0.0" && addr != "[::]") {
-		return addr, nil
-	}
-
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return "", fmt.Errorf("Failed to get interface addresses! Err: %v", err)
-	}
-
-	var ipAddr []byte
-
-	for _, rawAddr := range addrs {
-		var ip net.IP
-		switch addr := rawAddr.(type) {
-		case *net.IPAddr:
-			ip = addr.IP
-		case *net.IPNet:
-			ip = addr.IP
-		default:
-			continue
-		}
-
-		if ip.To4() == nil {
-			continue
-		}
-
-		if !isPrivateIP(ip.String()) {
-			continue
-		}
-
-		ipAddr = ip
-		break
-	}
-
-	if ipAddr == nil {
-		return "", fmt.Errorf("No private IP address found, and explicit IP not provided")
-	}
-
-	return net.IP(ipAddr).String(), nil
-}
-
-func isPrivateIP(ipAddr string) bool {
-	ip := net.ParseIP(ipAddr)
-	for _, priv := range privateBlocks {
-		if priv.Contains(ip) {
-			return true
-		}
-	}
-	return false
 }

--- a/server/grpc/extractor_test.go
+++ b/server/grpc/extractor_test.go
@@ -18,25 +18,6 @@ func (t *testHandler) Test(ctx context.Context, req *testRequest, rsp *testRespo
 	return nil
 }
 
-func TestExtractAddress(t *testing.T) {
-	data := []struct {
-		Input  string
-		Output string
-	}{
-		{"10.0.0.1", "10.0.0.1"},
-	}
-
-	for _, d := range data {
-		addr, err := extractAddress(d.Input)
-		if err != nil {
-			t.Errorf("Expected %s: %v", d.Output, err)
-		}
-		if addr != d.Output {
-			t.Errorf("Expected %s, got %s", d.Output, addr)
-		}
-	}
-}
-
 func TestExtractEndpoint(t *testing.T) {
 	handler := &testHandler{}
 	typ := reflect.TypeOf(handler)

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -23,6 +23,7 @@ import (
 	meta "github.com/micro/go-micro/metadata"
 	"github.com/micro/go-micro/registry"
 	"github.com/micro/go-micro/server"
+	"github.com/micro/misc/lib/addr"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -584,7 +585,7 @@ func (g *grpcServer) Register() error {
 		host = parts[0]
 	}
 
-	addr, err := extractAddress(host)
+	addr, err := addr.Extract(host)
 	if err != nil {
 		return err
 	}
@@ -704,7 +705,7 @@ func (g *grpcServer) Deregister() error {
 		host = parts[0]
 	}
 
-	addr, err := extractAddress(host)
+	addr, err := addr.Extract(host)
 	if err != nil {
 		return err
 	}

--- a/server/http/extractor.go
+++ b/server/http/extractor.go
@@ -1,78 +1,14 @@
 package http
 
 import (
-	"fmt"
-	"net"
 	"strconv"
 	"strings"
 
 	"github.com/micro/go-micro/registry"
 	"github.com/micro/go-micro/server"
+
+	"github.com/micro/misc/lib/addr"
 )
-
-var (
-	privateBlocks []*net.IPNet
-)
-
-func init() {
-	for _, b := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"} {
-		if _, block, err := net.ParseCIDR(b); err == nil {
-			privateBlocks = append(privateBlocks, block)
-		}
-	}
-}
-
-func extractAddress(addr string) (string, error) {
-	if len(addr) > 0 && (addr != "0.0.0.0" && addr != "[::]") {
-		return addr, nil
-	}
-
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return "", fmt.Errorf("Failed to get interface addresses! Err: %v", err)
-	}
-
-	var ipAddr []byte
-
-	for _, rawAddr := range addrs {
-		var ip net.IP
-		switch addr := rawAddr.(type) {
-		case *net.IPAddr:
-			ip = addr.IP
-		case *net.IPNet:
-			ip = addr.IP
-		default:
-			continue
-		}
-
-		if ip.To4() == nil {
-			continue
-		}
-
-		if !isPrivateIP(ip.String()) {
-			continue
-		}
-
-		ipAddr = ip
-		break
-	}
-
-	if ipAddr == nil {
-		return "", fmt.Errorf("No private IP address found, and explicit IP not provided")
-	}
-
-	return net.IP(ipAddr).String(), nil
-}
-
-func isPrivateIP(ipAddr string) bool {
-	ip := net.ParseIP(ipAddr)
-	for _, priv := range privateBlocks {
-		if priv.Contains(ip) {
-			return true
-		}
-	}
-	return false
-}
 
 func serviceDef(opts server.Options) *registry.Service {
 	var advt, host string
@@ -92,7 +28,7 @@ func serviceDef(opts server.Options) *registry.Service {
 		host = parts[0]
 	}
 
-	addr, err := extractAddress(host)
+	addr, err := addr.Extract(host)
 	if err != nil {
 		addr = host
 	}


### PR DESCRIPTION
I've not had a chance to fully test other than "go test" but it seems the extractAddress function is duplicated in a few of the packages and is a near mirror image of the existing Extract function in micro/misc/lib/addr

Not sure what your thought are around moving them to micro/misc/lib/addr and having a dependancy on that package? 