### PR TITLE
opencensus: add tracing wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A repository for micro plugins
 
 ## Overview
 
-Micro tooling is built on a powerful pluggable architecture. Plugins can be swapped out with zero code changes. 
+Micro tooling is built on a powerful pluggable architecture. Plugins can be swapped out with zero code changes.
 This repository contains plugins for all micro related tools. Read on for further info.
 
 Check out the [Micro on NATS](https://micro.mu/blog/2016/04/11/micro-on-nats.html) blog post to learn more about plugins.
@@ -13,31 +13,30 @@ Follow us on [Twitter](https://twitter.com/microhq) or join the [Slack](http://s
 
 ## Getting Started
 
-- [Contents](#contents)
-- [Usage](#usage)
-- [Build Pattern](#build-pattern)
-- [Contributions](#contributions)
+* [Contents](#contents)
+* [Usage](#usage)
+* [Build Pattern](#build-pattern)
+* [Contributions](#contributions)
 
 ## Contents
 
 Contents of this repository:
 
-Directory	|	Description
----		|	---
-Broker		|	PubSub messaging; NATS, NSQ, RabbitMQ, Kafka	
-Client		|	RPC Clients; gRPC, HTTP
-Codec		|	Message Encoding; BSON, Mercury
-KV		|	Key-Value; Memcached, Redis
-Metrics		|	Instrumentation; Statsd, Telegraf, Prometheus
-Micro		|	Micro Toolkit Plugins
-Registry	|	Service Discovery; Etcd, Gossip, NATS
-Selector	|	Load balancing; Label, Cache, Static
-Server		|	RPC Servers; gRPC, HTTP
-Sync		|	Locking/Leadership election; Consul, Etcd
-Trace		|	Distributed Tracing; Zipkin
-Transport	|	Bidirectional Streaming; NATS, RabbitMQ
-Wrappers	|	Middleware; Circuit Breakers, Rate Limiting
-
+| Directory | Description                                          |
+| --------- | ---------------------------------------------------- |
+| Broker    | PubSub messaging; NATS, NSQ, RabbitMQ, Kafka         |
+| Client    | RPC Clients; gRPC, HTTP                              |
+| Codec     | Message Encoding; BSON, Mercury                      |
+| KV        | Key-Value; Memcached, Redis                          |
+| Metrics   | Instrumentation; Statsd, Telegraf, Prometheus        |
+| Micro     | Micro Toolkit Plugins                                |
+| Registry  | Service Discovery; Etcd, Gossip, NATS                |
+| Selector  | Load balancing; Label, Cache, Static                 |
+| Server    | RPC Servers; gRPC, HTTP                              |
+| Sync      | Locking/Leadership election; Consul, Etcd            |
+| Trace     | Distributed Tracing; Zipkin                          |
+| Transport | Bidirectional Streaming; NATS, RabbitMQ              |
+| Wrappers  | Middleware; Circuit Breakers, Rate Limiting, Tracing |
 
 ## Usage
 
@@ -59,7 +58,7 @@ func main() {
 }
 ```
 
-The same is achieved when calling ```service.Init```
+The same is achieved when calling `service.Init`
 
 ```go
 import (
@@ -112,11 +111,12 @@ func main() {
 
 ## Build Pattern
 
-An anti-pattern is modifying the `main.go` file to include plugins. Best practice recommendation is to include 
-plugins in a separate file and rebuild with it included. This allows for automation of building plugins and 
+An anti-pattern is modifying the `main.go` file to include plugins. Best practice recommendation is to include
+plugins in a separate file and rebuild with it included. This allows for automation of building plugins and
 clean separation of concerns.
 
 Create file plugins.go
+
 ```go
 package main
 
@@ -128,11 +128,13 @@ import (
 ```
 
 Build with plugins.go
+
 ```shell
 go build -o service main.go plugins.go
 ```
 
 Run with plugins
+
 ```shell
 MICRO_BROKER=rabbitmq \
 MICRO_REGISTRY=kubernetes \
@@ -144,8 +146,7 @@ service
 
 A few contributions by others
 
-Feature		|	Description		|	Author
-----------	|	------------		|	--------
-[Registry/Kubernetes](https://godoc.org/github.com/micro/go-plugins/registry/kubernetes)	|	Service discovery via the Kubernetes API	|	[@nickjackson](https://github.com/nickjackson)
-[Registry/Zookeeper](https://godoc.org/github.com/micro/go-plugins/registry/zookeeper)	|	Service discovery using Zookeeper	|	[@HeavyHorst](https://github.com/HeavyHorst)
-
+| Feature                                                                                  | Description                              | Author                                         |
+| ---------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------- |
+| [Registry/Kubernetes](https://godoc.org/github.com/micro/go-plugins/registry/kubernetes) | Service discovery via the Kubernetes API | [@nickjackson](https://github.com/nickjackson) |
+| [Registry/Zookeeper](https://godoc.org/github.com/micro/go-plugins/registry/zookeeper)   | Service discovery using Zookeeper        | [@HeavyHorst](https://github.com/HeavyHorst)   |

--- a/wrapper/trace/opencensus/README.md
+++ b/wrapper/trace/opencensus/README.md
@@ -1,0 +1,14 @@
+# OpenCensus wrappers
+
+OpenCensus wrappers propagate traces (spans) accross services.
+
+## Usage
+
+```go
+service := micro.NewService(
+    micro.Name("go.micro.srv.greeter"),
+    micro.WrapClient(opencensus.NewClientWrapper()),
+    micro.WrapHandler(opencensus.NewHandlerWrapper()),
+    micro.WrapSubscriber(opencensus.NewSubscriberWrapper()),
+)
+```

--- a/wrapper/trace/opencensus/opencensus.go
+++ b/wrapper/trace/opencensus/opencensus.go
@@ -1,0 +1,158 @@
+// Package opencensus provides wrappers for OpenCensus tracing.
+package opencensus
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/micro/go-log"
+	"github.com/micro/go-micro/client"
+	"github.com/micro/go-micro/metadata"
+	"github.com/micro/go-micro/server"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+const (
+	// TracePropagationField is the key for the tracing context
+	// that will be injected in go-micro's metadata.
+	TracePropagationField = "X-Trace-Context"
+)
+
+// clientWrapper wraps an RPC client and adds tracing.
+type clientWrapper struct {
+	client.Client
+}
+
+func injectTraceIntoCtx(ctx context.Context, span *trace.Span) context.Context {
+	md, ok := metadata.FromContext(ctx)
+	if !ok {
+		md = make(map[string]string)
+	}
+
+	spanCtx := propagation.Binary(span.SpanContext())
+	md[TracePropagationField] = base64.RawStdEncoding.EncodeToString(spanCtx)
+
+	return metadata.NewContext(ctx, md)
+}
+
+// Call implements client.Client.Call.
+func (w *clientWrapper) Call(
+	ctx context.Context,
+	req client.Request,
+	rsp interface{},
+	opts ...client.CallOption) error {
+	ctx, span := trace.StartSpan(ctx, fmt.Sprintf("rpc/call/%s/%s", req.Service(), req.Method()))
+	defer span.End()
+
+	ctx = injectTraceIntoCtx(ctx, span)
+
+	return w.Client.Call(ctx, req, rsp, opts...)
+}
+
+// Publish implements client.Client.Publish.
+func (w *clientWrapper) Publish(ctx context.Context, p client.Publication, opts ...client.PublishOption) error {
+	ctx, span := trace.StartSpan(ctx, fmt.Sprintf("rpc/publish/%s", p.Topic()))
+	defer span.End()
+
+	ctx = injectTraceIntoCtx(ctx, span)
+
+	return w.Client.Publish(ctx, p, opts...)
+}
+
+// WrapClient implements client.Wrapper to wrap a client
+// and add monitoring to outgoing requests.
+func WrapClient(c client.Client) client.Client {
+	return &clientWrapper{c}
+}
+
+// NewClientWrapper returns a client.Wrapper
+// that adds monitoring to outgoing requests.
+func NewClientWrapper() client.Wrapper {
+	return WrapClient
+}
+
+func getTraceFromCtx(ctx context.Context) *trace.SpanContext {
+	md, ok := metadata.FromContext(ctx)
+	if !ok {
+		md = make(map[string]string)
+	}
+
+	encodedTraceCtx, ok := md[TracePropagationField]
+	if !ok {
+		log.Log("Missing trace context in incoming request")
+		return nil
+	}
+
+	traceCtxBytes, err := base64.RawStdEncoding.DecodeString(encodedTraceCtx)
+	if err != nil {
+		log.Logf("Could not decode trace context: %s", err.Error())
+		return nil
+	}
+
+	spanCtx, ok := propagation.FromBinary(traceCtxBytes)
+	if !ok {
+		log.Log("Could not decode trace context from binary")
+		return nil
+	}
+
+	return &spanCtx
+}
+
+// NewHandlerWrapper returns a server.HandlerWrapper
+// that adds tracing to incoming requests.
+func NewHandlerWrapper() server.HandlerWrapper {
+	return func(fn server.HandlerFunc) server.HandlerFunc {
+		return func(ctx context.Context, req server.Request, rsp interface{}) error {
+			var span *trace.Span
+			defer span.End()
+
+			spanCtx := getTraceFromCtx(ctx)
+			if spanCtx != nil {
+				span = trace.NewSpanWithRemoteParent(
+					fmt.Sprintf("rpc/handle/%s/%s", req.Service(), req.Method()),
+					*spanCtx,
+					trace.StartOptions{},
+				)
+				ctx = trace.WithSpan(ctx, span)
+			} else {
+				ctx, span = trace.StartSpan(
+					ctx,
+					fmt.Sprintf("rpc/handle/%s/%s", req.Service(), req.Method()),
+				)
+			}
+
+			return fn(ctx, req, rsp)
+		}
+	}
+}
+
+// NewSubscriberWrapper returns a server.SubscriberWrapper
+// that adds tracing to subscription requests.
+func NewSubscriberWrapper() server.SubscriberWrapper {
+	return func(fn server.SubscriberFunc) server.SubscriberFunc {
+		return func(ctx context.Context, p server.Publication) error {
+			var span *trace.Span
+			defer span.End()
+
+			spanCtx := getTraceFromCtx(ctx)
+			if spanCtx != nil {
+				span = trace.NewSpanWithRemoteParent(
+					fmt.Sprintf("rpc/subscribe/%s", p.Topic()),
+					*spanCtx,
+					trace.StartOptions{},
+				)
+				ctx = trace.WithSpan(ctx, span)
+			} else {
+				ctx, span = trace.StartSpan(
+					ctx,
+					fmt.Sprintf("rpc/subscribe/%s", p.Topic()),
+				)
+			}
+
+			return fn(ctx, p)
+		}
+	}
+}


### PR DESCRIPTION
Add simple wrappers for OpenCensus distributed tracing.
I'm quite new to both OpenCensus and go-micro, so feedback is more than welcome.
I don't know how I could efficiently unit test this, do you have a suggestion?

It would be useful to have a review from someone in the OpenCensus team, maybe @rakyll could provide some quick feedback?

Note: my markdown plugin automatically reformatted the main README (I only added a mention to tracing wrappers). Let me know if you want me to revert that.