### PR TITLE
opencensus: add error tagging and metrics

### DIFF
--- a/wrapper/trace/opencensus/README.md
+++ b/wrapper/trace/opencensus/README.md
@@ -12,3 +12,20 @@ service := micro.NewService(
     micro.WrapSubscriber(opencensus.NewSubscriberWrapper()),
 )
 ```
+
+### Views
+
+The OpenCensus package exposes some convenience views.
+Don't forget to register these views:
+
+```go
+// Register to all RPC server views.
+if err := view.Register(opencensus.DefaultServerViews...); err != nil {
+    log.Fatal(err)
+}
+
+// Register to all RPC client views.
+if err := view.Register(opencensus.DefaultClientViews...); err != nil {
+    log.Fatal(err)
+}
+```

--- a/wrapper/trace/opencensus/opencensus.go
+++ b/wrapper/trace/opencensus/opencensus.go
@@ -62,16 +62,12 @@ func (w *clientWrapper) Publish(ctx context.Context, p client.Publication, opts 
 	return w.Client.Publish(ctx, p, opts...)
 }
 
-// WrapClient implements client.Wrapper to wrap a client
-// and add monitoring to outgoing requests.
-func WrapClient(c client.Client) client.Client {
-	return &clientWrapper{c}
-}
-
 // NewClientWrapper returns a client.Wrapper
 // that adds monitoring to outgoing requests.
 func NewClientWrapper() client.Wrapper {
-	return WrapClient
+	return func(c client.Client) client.Client {
+		return &clientWrapper{c}
+	}
 }
 
 func getTraceFromCtx(ctx context.Context) *trace.SpanContext {

--- a/wrapper/trace/opencensus/opencensus.go
+++ b/wrapper/trace/opencensus/opencensus.go
@@ -78,7 +78,6 @@ func getTraceFromCtx(ctx context.Context) *trace.SpanContext {
 
 	encodedTraceCtx, ok := md[TracePropagationField]
 	if !ok {
-		log.Log("Missing trace context in incoming request")
 		return nil
 	}
 

--- a/wrapper/trace/opencensus/stats.go
+++ b/wrapper/trace/opencensus/stats.go
@@ -1,0 +1,142 @@
+package opencensus
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+// The following client RPC measures are supported for use in custom views.
+var (
+	ClientRequestCount = stats.Int64("opencensus.io/rpc/client/request_count", "Number of RPC requests started", stats.UnitNone)
+	ClientLatency      = stats.Float64("opencensus.io/rpc/client/latency", "End-to-end latency", stats.UnitMilliseconds)
+)
+
+// The following server RPC measures are supported for use in custom views.
+var (
+	ServerRequestCount = stats.Int64("opencensus.io/rpc/server/request_count", "Number of RPC requests received", stats.UnitNone)
+	ServerLatency      = stats.Float64("opencensus.io/rpc/server/latency", "End-to-end latency", stats.UnitMilliseconds)
+)
+
+// The following tags are applied to stats recorded by this package.
+// Service and Method are applied to all measures.
+// StatusCode is not applied to ClientRequestCount or ServerRequestCount,
+// since it is recorded before the status is known.
+var (
+	// StatusCode is the RPC status code.
+	StatusCode, _ = tag.NewKey("rpc.status")
+
+	// Service is the name of the micro-service.
+	Service, _ = tag.NewKey("rpc.service")
+
+	// Method is the service method called.
+	Method, _ = tag.NewKey("rpc.method")
+)
+
+// Default distributions used by views in this package.
+var (
+	DefaultLatencyDistribution = view.Distribution(0, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
+)
+
+// This package provides some convenience views.
+// You need to subscribe to the views for data to actually be collected.
+var (
+	ClientRequestCountView = &view.View{
+		Name:        "opencensus.io/rpc/client/request_count",
+		Description: "Count of RPC requests started",
+		Measure:     ClientRequestCount,
+		Aggregation: view.Count(),
+	}
+
+	ClientLatencyView = &view.View{
+		Name:        "opencensus.io/rpc/client/latency",
+		Description: "Latency distribution of RPC requests",
+		Measure:     ClientLatency,
+		Aggregation: DefaultLatencyDistribution,
+	}
+
+	ClientRequestCountByMethod = &view.View{
+		Name:        "opencensus.io/rpc/client/request_count_by_method",
+		Description: "Client request count by RPC method",
+		TagKeys:     []tag.Key{Method},
+		Measure:     ClientRequestCount,
+		Aggregation: view.Count(),
+	}
+
+	ClientResponseCountByStatusCode = &view.View{
+		Name:        "opencensus.io/rpc/client/response_count_by_status_code",
+		Description: "Client response count by RPC status code",
+		TagKeys:     []tag.Key{StatusCode},
+		Measure:     ClientLatency,
+		Aggregation: view.Count(),
+	}
+
+	ServerRequestCountView = &view.View{
+		Name:        "opencensus.io/rpc/server/request_count",
+		Description: "Count of RPC requests received",
+		Measure:     ServerRequestCount,
+		Aggregation: view.Count(),
+	}
+
+	ServerLatencyView = &view.View{
+		Name:        "opencensus.io/rpc/server/latency",
+		Description: "Latency distribution of RPC requests",
+		Measure:     ServerLatency,
+		Aggregation: DefaultLatencyDistribution,
+	}
+
+	ServerRequestCountByMethod = &view.View{
+		Name:        "opencensus.io/rpc/server/request_count_by_method",
+		Description: "Server request count by RPC method",
+		TagKeys:     []tag.Key{Method},
+		Measure:     ServerRequestCount,
+		Aggregation: view.Count(),
+	}
+
+	ServerResponseCountByStatusCode = &view.View{
+		Name:        "opencensus.io/rpc/server/response_count_by_status_code",
+		Description: "Server response count by RPC status code",
+		TagKeys:     []tag.Key{StatusCode},
+		Measure:     ServerLatency,
+		Aggregation: view.Count(),
+	}
+)
+
+// DefaultClientViews are the default client views provided by this package.
+var DefaultClientViews = []*view.View{
+	ClientRequestCountView,
+	ClientLatencyView,
+	ClientRequestCountByMethod,
+	ClientResponseCountByStatusCode,
+}
+
+// DefaultServerViews are the default server views provided by this package.
+var DefaultServerViews = []*view.View{
+	ServerRequestCountView,
+	ServerLatencyView,
+	ServerRequestCountByMethod,
+	ServerResponseCountByStatusCode,
+}
+
+// StatsProfile groups metrics-related data.
+type StatsProfile struct {
+	Role           string
+	CountMeasure   *stats.Int64Measure
+	LatencyMeasure *stats.Float64Measure
+}
+
+var (
+	// ClientProfile is used for RPC clients.
+	ClientProfile = &StatsProfile{
+		Role:           "client",
+		CountMeasure:   ClientRequestCount,
+		LatencyMeasure: ClientLatency,
+	}
+
+	// ServerProfile is used for RPC servers.
+	ServerProfile = &StatsProfile{
+		Role:           "server",
+		CountMeasure:   ServerRequestCount,
+		LatencyMeasure: ServerLatency,
+	}
+)

--- a/wrapper/trace/opencensus/status.go
+++ b/wrapper/trace/opencensus/status.go
@@ -1,0 +1,46 @@
+package opencensus
+
+import (
+	"fmt"
+
+	microerr "github.com/micro/go-micro/errors"
+
+	"go.opencensus.io/trace"
+
+	"google.golang.org/genproto/googleapis/rpc/code"
+)
+
+var microCodeToStatusCode = map[int32]code.Code{
+	400: code.Code_INVALID_ARGUMENT,
+	401: code.Code_UNAUTHENTICATED,
+	403: code.Code_PERMISSION_DENIED,
+	404: code.Code_NOT_FOUND,
+	409: code.Code_ABORTED,
+	500: code.Code_INTERNAL,
+}
+
+// endSpan sets the span status depending on the error and ends the span.
+func endSpan(span *trace.Span, err error) {
+	if err != nil {
+		microErr, ok := err.(*microerr.Error)
+		if ok {
+			statusCode := microErr.Code
+			code, ok := microCodeToStatusCode[microErr.Code]
+			if ok {
+				statusCode = int32(code)
+			}
+
+			span.SetStatus(trace.Status{
+				Code:    statusCode,
+				Message: fmt.Sprintf("%s: %s", microErr.Id, microErr.Detail),
+			})
+		} else {
+			span.SetStatus(trace.Status{
+				Code:    int32(code.Code_UNKNOWN),
+				Message: err.Error(),
+			})
+		}
+	}
+
+	span.End()
+}

--- a/wrapper/trace/opencensus/status.go
+++ b/wrapper/trace/opencensus/status.go
@@ -19,8 +19,7 @@ var microCodeToStatusCode = map[int32]code.Code{
 	500: code.Code_INTERNAL,
 }
 
-// endSpan sets the span status depending on the error and ends the span.
-func endSpan(span *trace.Span, err error) {
+func getResponseStatus(err error) trace.Status {
 	if err != nil {
 		microErr, ok := err.(*microerr.Error)
 		if ok {
@@ -30,17 +29,17 @@ func endSpan(span *trace.Span, err error) {
 				statusCode = int32(code)
 			}
 
-			span.SetStatus(trace.Status{
+			return trace.Status{
 				Code:    statusCode,
 				Message: fmt.Sprintf("%s: %s", microErr.Id, microErr.Detail),
-			})
-		} else {
-			span.SetStatus(trace.Status{
-				Code:    int32(code.Code_UNKNOWN),
-				Message: err.Error(),
-			})
+			}
+		}
+
+		return trace.Status{
+			Code:    int32(code.Code_UNKNOWN),
+			Message: err.Error(),
 		}
 	}
 
-	span.End()
+	return trace.Status{}
 }

--- a/wrapper/trace/opencensus/tracker.go
+++ b/wrapper/trace/opencensus/tracker.go
@@ -1,0 +1,81 @@
+package opencensus
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"go.opencensus.io/trace"
+)
+
+type tracker struct {
+	startedAt time.Time
+
+	profile *StatsProfile
+	span    *trace.Span
+
+	method  string
+	service string
+}
+
+type requestDescriptor interface {
+	Service() string
+	Method() string
+}
+
+type publicationDescriptor interface {
+	Topic() string
+}
+
+// newRequestTracker creates a new tracker for an RPC request (client or server).
+func newRequestTracker(req requestDescriptor, profile *StatsProfile) *tracker {
+	return &tracker{
+		profile: profile,
+		method:  req.Method(),
+		service: req.Service(),
+	}
+}
+
+// newPublicationTracker creates a new tracker for a publication (client or server).
+func newPublicationTracker(pub publicationDescriptor, profile *StatsProfile) *tracker {
+	return &tracker{
+		profile: profile,
+		method:  pub.Topic(),
+		service: "pubsub",
+	}
+}
+
+// start monitoring a request. You can choose to let this method
+// start a span for the request or attach one later.
+func (t *tracker) start(ctx context.Context, startSpan bool) context.Context {
+	t.startedAt = time.Now()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(Service, t.service), tag.Upsert(Method, t.method))
+	stats.Record(ctx, t.profile.CountMeasure.M(1))
+
+	if startSpan {
+		ctx, t.span = trace.StartSpan(
+			ctx,
+			fmt.Sprintf("rpc/%s/%s/%s", t.profile.Role, t.service, t.method),
+		)
+	}
+
+	return ctx
+}
+
+// end a request's monitoring session. If there is a span ongoing, it will
+// be ended and metrics will be recorded.
+func (t *tracker) end(ctx context.Context, err error) {
+	status := getResponseStatus(err)
+
+	ctx, _ = tag.New(ctx, tag.Upsert(StatusCode, strconv.Itoa(int(status.Code))))
+	stats.Record(ctx, t.profile.LatencyMeasure.M(float64(time.Since(t.startedAt))/float64(time.Millisecond)))
+
+	if t.span != nil {
+		t.span.SetStatus(status)
+		t.span.End()
+	}
+}


### PR DESCRIPTION
I'm now setting the span status based on the error received.
I also added client and server metrics (non-exhaustive compared to OpenCensus' ochttp and ocgrpc plugins, but it's a start).

Here is a trace where the RPC failed with 404 (status code = 5):

![tracing-rpc-error](https://user-images.githubusercontent.com/31281497/38372350-e3326690-38ee-11e8-9512-2a308dd77e60.png)

Here is a dashboard I created on GCP from the newly recorded metrics (on a dev environment with no traffic, but we see the metrics look correct):

![tracing-rpc-metrics](https://user-images.githubusercontent.com/31281497/38372394-fef381e8-38ee-11e8-9052-04ff20aba54b.png)

@rakyll: is using the googleapis error code generated list the recommended way? Is there a more convenient error code mapping exposed somewhere (maybe in opencensus-go) or is it fine for now?

Don't hesitate to suggest anything that would make this PR cleaner/more future-proof if there are things that look clunky.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/micro/go-plugins/167)
<!-- Reviewable:end -->
