### PR TITLE
FIXED (partially) error introduced by grpc changes

### DIFF
--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -258,9 +258,8 @@ func (g *grpcServer) sendResponse(t transport.ServerTransport, stream *transport
 }
 
 func (g *grpcServer) processRequest(t transport.ServerTransport, stream *transport.Stream, service *service, mtype *methodType, codec grpc.Codec, ct string, ctx context.Context) (err error) {
-	p := &parser{r: stream}
 	for {
-		pf, req, err := p.recvMsg(defaultMaxMsgSize)
+		pf, req, err := recvMsg(stream, defaultMaxMsgSize)
 		if err == io.EOF {
 			// The entire stream is done (for unary RPC only).
 			return err
@@ -286,19 +285,10 @@ func (g *grpcServer) processRequest(t transport.ServerTransport, stream *transpo
 			return err
 		}
 
-		if err := checkRecvPayload(pf, stream.RecvCompress(), nil); err != nil {
-			switch err := err.(type) {
-			case *rpcError:
-				if err := t.WriteStatus(stream, status.New(err.code, err.desc)); err != nil {
-					log.Logf("grpc: Server.processUnaryRPC failed to write status %v", err)
-				}
-			default:
-				if err := t.WriteStatus(stream, status.New(codes.Internal, err.Error())); err != nil {
-					log.Logf("grpc: Server.processUnaryRPC failed to write status %v", err)
-				}
-
-			}
-			return err
+		if err := checkRecvPayload(stream.RecvCompress(), pf); err != nil {
+			// @todo - removed switch that was here as it was
+			// no longer a valid type to switch on
+			return nil
 		}
 
 		// status code/desc
@@ -422,7 +412,6 @@ func (g *grpcServer) processStream(t transport.ServerTransport, stream *transpor
 		request:    r,
 		t:          t,
 		s:          stream,
-		p:          &parser{r: stream},
 		codec:      codec,
 		maxMsgSize: defaultMaxMsgSize,
 	}

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -250,11 +250,11 @@ func (g *grpcServer) serveStream(t transport.ServerTransport, stream *transport.
 }
 
 func (g *grpcServer) sendResponse(t transport.ServerTransport, stream *transport.Stream, msg interface{}, codec grpc.Codec, opts *transport.Options) error {
-	hd, p, err := encode(codec, msg, nil, nil, nil)
+	p, err := encode(codec, msg, nil, nil, nil)
 	if err != nil {
 		log.Fatalf("grpc: Server failed to encode response %v", err)
 	}
-	return t.Write(stream, hd, p, opts)
+	return t.Write(stream, p, opts)
 }
 
 func (g *grpcServer) processRequest(t transport.ServerTransport, stream *transport.Stream, service *service, mtype *methodType, codec grpc.Codec, ct string, ctx context.Context) (err error) {

--- a/server/grpc/stream.go
+++ b/server/grpc/stream.go
@@ -49,7 +49,6 @@ import (
 type rpcStream struct {
 	t          transport.ServerTransport
 	s          *transport.Stream
-	p          *parser
 	codec      grpc.Codec
 	cp         grpc.Compressor
 	dc         grpc.Decompressor
@@ -96,7 +95,7 @@ func (r *rpcStream) Send(m interface{}) (err error) {
 }
 
 func (r *rpcStream) Recv(m interface{}) (err error) {
-	if err := recv(r.p, r.codec, r.s, r.dc, m, r.maxMsgSize); err != nil {
+	if err := recv(r.codec, r.s, r.dc, m, r.maxMsgSize); err != nil {
 		if err == io.EOF {
 			return err
 		}

--- a/server/grpc/stream.go
+++ b/server/grpc/stream.go
@@ -79,7 +79,7 @@ func (r *rpcStream) Context() context.Context {
 }
 
 func (r *rpcStream) Send(m interface{}) (err error) {
-	hd, out, err := encode(r.codec, m, r.cp, r.cbuf, nil)
+	out, err := encode(r.codec, m, r.cp, r.cbuf, nil)
 	defer func() {
 		if r.cbuf != nil {
 			r.cbuf.Reset()
@@ -89,7 +89,7 @@ func (r *rpcStream) Send(m interface{}) (err error) {
 		err = Errorf(codes.Internal, "grpc: %v", err)
 		return err
 	}
-	if err := r.t.Write(r.s, hd, out, &transport.Options{Last: false}); err != nil {
+	if err := r.t.Write(r.s, out, &transport.Options{Last: false}); err != nil {
 		return toRPCErr(err)
 	}
 	return nil


### PR DESCRIPTION
# Problem 
gRPC have recently committed some changes to the go-grpc library which could introduce some breaking changes to this repo

# Solution
This is not a complete solution, I don't understand the internals of the gRPC streams enough to call it, and there's some stuff around compression that might need fixing further on this PR. But I hope this is at least a start.

If you want to advice me on how to complete this, give me a shout!

Commit in question:
https://github.com/grpc/grpc-go/commit/7a8c9895074e03bc7fcff30bd561eaef4fa76dfa

Line currently breaking:
https://github.com/micro/go-plugins/blob/master/server/grpc/stream.go#L92
