### PR TITLE
refactor(import): updated to use the new import path for go-nats

### DIFF
--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -8,7 +8,7 @@ import (
 	"github.com/micro/go-micro/broker"
 	"github.com/micro/go-micro/broker/codec/json"
 	"github.com/micro/go-micro/cmd"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 type nbroker struct {

--- a/broker/nats/nats_test.go
+++ b/broker/nats/nats_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/micro/go-micro/broker"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 var addrTestCases = []struct {

--- a/broker/nats/options.go
+++ b/broker/nats/options.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/micro/go-micro/broker"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 type optionsKey struct{}

--- a/registry/nats/nats.go
+++ b/registry/nats/nats.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/micro/go-micro/cmd"
 	"github.com/micro/go-micro/registry"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 type natsRegistry struct {

--- a/registry/nats/options.go
+++ b/registry/nats/options.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/micro/go-micro/registry"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 type contextQuorumKey struct{}

--- a/registry/nats/options_test.go
+++ b/registry/nats/options_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-log/log"
 	"github.com/micro/go-micro/registry"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 var addrTestCases = []struct {

--- a/registry/nats/watcher.go
+++ b/registry/nats/watcher.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/micro/go-micro/registry"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 type natsWatcher struct {

--- a/transport/nats/nats.go
+++ b/transport/nats/nats.go
@@ -13,7 +13,7 @@ import (
 	"github.com/micro/go-micro/server"
 	"github.com/micro/go-micro/transport"
 	"github.com/micro/go-micro/transport/codec/json"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 type ntport struct {

--- a/transport/nats/nats_test.go
+++ b/transport/nats/nats_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-log/log"
 	"github.com/micro/go-micro/server"
 	"github.com/micro/go-micro/transport"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 var addrTestCases = []struct {

--- a/transport/nats/options.go
+++ b/transport/nats/options.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/micro/go-micro/transport"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 type optionsKey struct{}


### PR DESCRIPTION
Nats have updated their repo names and breaks the import paths.

`github.com/nats-io/nats` changed to `github.com/nats-io/go-nats`

And their roadmap repo `github.com/nats-io/roadmap` was changed to `github.com/nats-io/nats`