### PR TITLE
update udp dependency

### DIFF
--- a/transport/utp/client.go
+++ b/transport/utp/client.go
@@ -1,8 +1,10 @@
 package utp
 
 import (
+	"errors"
 	"time"
 
+	"github.com/micro/go-log"
 	"github.com/micro/go-micro/transport"
 )
 
@@ -26,5 +28,16 @@ func (u *utpClient) Recv(m *transport.Message) error {
 }
 
 func (u *utpClient) Close() error {
-	return u.conn.Close()
+	err1 := u.conn.Close()
+	if err1 != nil {
+		log.Log("fail to close utp connection error:", err1)
+	}
+	err2 := u.socket.Close()
+	if err2 != nil {
+		log.Log("fail to close utp socket error:", err2)
+	}
+	if err1 != nil || err2 != nil {
+		return errors.New("fail to close utp client")
+	}
+	return nil
 }

--- a/transport/utp/utp.go
+++ b/transport/utp/utp.go
@@ -7,9 +7,9 @@ import (
 	"net"
 	"time"
 
+	"github.com/anacrolix/go-libutp"
 	"github.com/micro/go-micro/cmd"
 	"github.com/micro/go-micro/transport"
-	"github.com/anacrolix/go-libutp"
 )
 
 type utpTransport struct {

--- a/transport/utp/utp.go
+++ b/transport/utp/utp.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/micro/go-micro/cmd"
 	"github.com/micro/go-micro/transport"
+	"github.com/anacrolix/go-libutp"
 )
 
 type utpTransport struct {
@@ -24,6 +25,7 @@ type utpListener struct {
 type utpClient struct {
 	dialOpts transport.DialOptions
 	conn     net.Conn
+	socket   *utp.Socket
 	enc      *gob.Encoder
 	dec      *gob.Decoder
 	encBuf   *bufio.Writer


### PR DESCRIPTION
original utp repo https://github.com/anacrolix/utp is deprecated, and the recommend one is https://github.com/anacrolix/go-libutp

This PR replaced the utp implementation.

The new one is written by go & c++, and consumes more memory than the old one.