### PR TITLE
[#196] Bypass TLS certificate checks

### DIFF
--- a/registry/kubernetes/client/client.go
+++ b/registry/kubernetes/client/client.go
@@ -4,11 +4,11 @@ import (
 	"crypto/tls"
 	"errors"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"path"
 
-	"github.com/micro/go-log"
 	"github.com/micro/go-plugins/registry/kubernetes/client/api"
 	"github.com/micro/go-plugins/registry/kubernetes/client/watch"
 )
@@ -63,8 +63,22 @@ func detectNamespace() (string, error) {
 
 // NewClientByHost sets up a client by host
 func NewClientByHost(host string) Kubernetes {
+	var tc *tls.Config
+
+	// if skipTlsVerify {
+	// 	tc = &tls.Config{
+	// 		InsecureSkipVerify: true,
+	// 	}
+	// } else {
+	// 	tc = &tls.Config{}
+	// }
+
+	tc = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
 	tr := &http.Transport{
-		TLSClientConfig:    &tls.Config{},
+		TLSClientConfig:    tc,
 		DisableCompression: true,
 	}
 

--- a/registry/kubernetes/client/client.go
+++ b/registry/kubernetes/client/client.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/micro/go-plugins/registry/kubernetes/client/api"
-	"github.com/micro/go-plugins/registry/kubernetes/client/watch"
+	"github.com/comtom/go-plugins/registry/kubernetes/client/api"
+	"github.com/comtom/go-plugins/registry/kubernetes/client/watch"
 )
 
 var (
@@ -62,23 +62,9 @@ func detectNamespace() (string, error) {
 }
 
 // NewClientByHost sets up a client by host
-func NewClientByHost(host string) Kubernetes {
-	var tc *tls.Config
-
-	// if skipTlsVerify {
-	// 	tc = &tls.Config{
-	// 		InsecureSkipVerify: true,
-	// 	}
-	// } else {
-	// 	tc = &tls.Config{}
-	// }
-
-	tc = &tls.Config{
-		InsecureSkipVerify: true,
-	}
-
+func NewClientByHost(host string, TLSConfig *tls.Config) Kubernetes {
 	tr := &http.Transport{
-		TLSClientConfig:    tc,
+		TLSClientConfig:    TLSConfig,
 		DisableCompression: true,
 	}
 

--- a/registry/kubernetes/client/client.go
+++ b/registry/kubernetes/client/client.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/comtom/go-plugins/registry/kubernetes/client/api"
-	"github.com/comtom/go-plugins/registry/kubernetes/client/watch"
+	"github.com/micro/go-plugins/registry/kubernetes/client/api"
+	"github.com/micro/go-plugins/registry/kubernetes/client/watch"
 )
 
 var (

--- a/registry/kubernetes/kubernetes.go
+++ b/registry/kubernetes/kubernetes.go
@@ -258,7 +258,7 @@ func NewRegistry(opts ...registry.Option) registry.Registry {
 	if len(host) == 0 {
 		c = client.NewClientInCluster()
 	} else {
-		c = client.NewClientByHost(host)
+		c = client.NewClientByHost(host, options.TLSConfig)
 	}
 
 	return &kregistry{

--- a/registry/kubernetes/kubernetes.go
+++ b/registry/kubernetes/kubernetes.go
@@ -10,10 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/micro/go-plugins/registry/kubernetes/client"
-
 	"github.com/micro/go-micro/cmd"
 	"github.com/micro/go-micro/registry"
+	"github.com/micro/go-plugins/registry/kubernetes/client"
 )
 
 type kregistry struct {

--- a/registry/kubernetes/kubernetes_test.go
+++ b/registry/kubernetes/kubernetes_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"encoding/json"
+	"log"
 	"os"
 	"reflect"
 	"strconv"
@@ -9,11 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/micro/go-log"
+	"github.com/comtom/go-plugins/registry/kubernetes/client"
 	"github.com/micro/go-micro/registry"
 	"github.com/micro/go-micro/selector"
 	"github.com/micro/go-micro/selector/cache"
-	"github.com/micro/go-plugins/registry/kubernetes/client"
 	"github.com/micro/go-plugins/registry/kubernetes/client/mock"
 )
 

--- a/registry/kubernetes/watcher.go
+++ b/registry/kubernetes/watcher.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/comtom/go-plugins/registry/kubernetes/client"
+	"github.com/comtom/go-plugins/registry/kubernetes/client/watch"
 	"github.com/micro/go-log"
 	"github.com/micro/go-micro/registry"
-	"github.com/micro/go-plugins/registry/kubernetes/client"
-	"github.com/micro/go-plugins/registry/kubernetes/client/watch"
 )
 
 type k8sWatcher struct {

--- a/registry/kubernetes/watcher.go
+++ b/registry/kubernetes/watcher.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/comtom/go-plugins/registry/kubernetes/client"
-	"github.com/comtom/go-plugins/registry/kubernetes/client/watch"
 	"github.com/micro/go-log"
 	"github.com/micro/go-micro/registry"
+	"github.com/micro/go-plugins/registry/kubernetes/client"
+	"github.com/micro/go-plugins/registry/kubernetes/client/watch"
 )
 
 type k8sWatcher struct {


### PR DESCRIPTION
on registry/kubernetes/client/client.go:68 you can see an example showing how we could turn off or on SSL checks. I was unable to find a way to create a new `cli.BoolFlag` from this module.  On these commented lines we should check for this boolean flag.

NOTE: Don't merge this just yet. It will disable SSL certificate checks.