### PR TITLE
Resubscribe in case of rabbitmq connection failure

### DIFF
--- a/broker/rabbitmq/rabbitmq.go
+++ b/broker/rabbitmq/rabbitmq.go
@@ -4,6 +4,8 @@ package rabbitmq
 import (
 	"context"
 	"errors"
+	"sync"
+	"time"
 
 	"github.com/micro/go-micro/broker"
 	"github.com/micro/go-micro/cmd"
@@ -14,12 +16,20 @@ type rbroker struct {
 	conn  *rabbitMQConn
 	addrs []string
 	opts  broker.Options
+	mtx   sync.Mutex
+	wg    sync.WaitGroup
 }
 
 type subscriber struct {
-	opts  broker.SubscribeOptions
-	topic string
-	ch    *rabbitMQChannel
+	mtx          sync.Mutex
+	mayRun       bool
+	opts         broker.SubscribeOptions
+	topic        string
+	ch           *rabbitMQChannel
+	durableQueue bool
+	r            *rbroker
+	fn           func(msg amqp.Delivery)
+	headers      map[string]interface{}
 }
 
 type publication struct {
@@ -53,7 +63,77 @@ func (s *subscriber) Topic() string {
 }
 
 func (s *subscriber) Unsubscribe() error {
-	return s.ch.Close()
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.mayRun = false
+	if s.ch != nil {
+		return s.ch.Close()
+	}
+	return nil
+}
+
+func (s *subscriber) resubscribe() {
+	minResubscribeDelay := 100 * time.Millisecond
+	maxResubscribeDelay := 30 * time.Second
+	expFactor := time.Duration(2)
+	reSubscribeDelay := minResubscribeDelay
+	//loop until unsubscribe
+	for {
+		s.mtx.Lock()
+		mayRun := s.mayRun
+		s.mtx.Unlock()
+		if !mayRun {
+			// we are unsubscribed, showdown routine
+			return
+		}
+
+		select {
+		//check shutdown case
+		case <-s.r.conn.close:
+			//yep, its shutdown case
+			return
+			//wait until we reconect to rabbit
+		case <-s.r.conn.waitConnection:
+		}
+
+		// it may crash (panic) in case of Consume without connection, so recheck it
+		s.r.mtx.Lock()
+		if !s.r.conn.connected {
+			s.r.mtx.Unlock()
+			continue
+		}
+
+		ch, sub, err := s.r.conn.Consume(
+			s.opts.Queue,
+			s.topic,
+			s.headers,
+			s.opts.AutoAck,
+			s.durableQueue,
+		)
+
+		s.r.mtx.Unlock()
+		switch err {
+		case nil:
+			reSubscribeDelay = minResubscribeDelay
+			s.mtx.Lock()
+			s.ch = ch
+			s.mtx.Unlock()
+		default:
+			if reSubscribeDelay > maxResubscribeDelay {
+				reSubscribeDelay = maxResubscribeDelay
+			}
+			time.Sleep(reSubscribeDelay)
+			reSubscribeDelay *= expFactor
+			continue
+		}
+		for d := range sub {
+			s.r.wg.Add(1)
+			go func(d amqp.Delivery) {
+				s.fn(d)
+				s.r.wg.Done()
+			}(d)
+		}
+	}
 }
 
 func (r *rbroker) Publish(topic string, msg *broker.Message, opts ...broker.PublishOption) error {
@@ -98,17 +178,6 @@ func (r *rbroker) Subscribe(topic string, handler broker.Handler, opts ...broker
 		return nil, errors.New("connection is nil")
 	}
 
-	ch, sub, err := r.conn.Consume(
-		opt.Queue,
-		topic,
-		headers,
-		opt.AutoAck,
-		durableQueue,
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	fn := func(msg amqp.Delivery) {
 		header := make(map[string]string)
 		for k, v := range msg.Headers {
@@ -121,13 +190,12 @@ func (r *rbroker) Subscribe(topic string, handler broker.Handler, opts ...broker
 		handler(&publication{d: msg, m: m, t: msg.RoutingKey})
 	}
 
-	go func() {
-		for d := range sub {
-			go fn(d)
-		}
-	}()
+	sret := &subscriber{topic: topic, opts: opt, mayRun: true, r: r,
+		durableQueue: durableQueue, fn: fn, headers: headers}
 
-	return &subscriber{ch: ch, topic: topic, opts: opt}, nil
+	go sret.resubscribe()
+
+	return sret, nil
 }
 
 func (r *rbroker) Options() broker.Options {
@@ -163,7 +231,9 @@ func (r *rbroker) Disconnect() error {
 	if r.conn == nil {
 		return errors.New("connection is nil")
 	}
-	return r.conn.Close()
+	ret := r.conn.Close()
+	r.wg.Wait() // wait all goroutines
+	return ret
 }
 
 func NewBroker(opts ...broker.Option) broker.Broker {


### PR DESCRIPTION
- subscriber class is linked with its parent rbrocker to be able to reconnect
- moved resubscrube routine to gorotined subscriber class method (and passed all necessary fields as class fields)
- wait on channel in case of rabbitmq connection loose (at init channel was created and at once closed to simplify code)
- resubscribe in case of rmq connection restore with exp backoff (pulling with sleep from 100ms to 30s, x2 step)