### PR TITLE
Add a 'multi' transport

### DIFF
--- a/transport/multi/multi.go
+++ b/transport/multi/multi.go
@@ -1,0 +1,63 @@
+package multi
+
+import (
+	"errors"
+
+	"github.com/micro/go-micro/transport"
+)
+
+// Option to be passed to NewTransport
+type Option func(*multi)
+
+type multi struct {
+	transports []transport.Transport
+	listen     transport.Transport
+}
+
+func (m *multi) Dial(addr string, opts ...transport.DialOption) (client transport.Client, err error) {
+	err = errors.New("No transports provided")
+
+	for _, transport := range m.transports {
+		client, err = transport.Dial(addr, opts...)
+		if client != nil && err == nil {
+			return client, nil
+		}
+	}
+
+	return client, err
+}
+
+func (m *multi) Listen(addr string, opts ...transport.ListenOption) (transport.Listener, error) {
+	if m.listen != nil {
+		return m.listen.Listen(addr, opts...)
+	}
+	return nil, errors.New("Not supported")
+}
+
+func (m *multi) String() string {
+	return "multi"
+}
+
+// NewTransport will return a new multi Transport with the given options.
+func NewTransport(opts ...Option) transport.Transport {
+	m := &multi{}
+	for _, o := range opts {
+		o(m)
+	}
+	return m
+}
+
+// WithTransports allows you to specify which transports in the order
+// of use that you wish to have them attempted.
+func WithTransports(transport ...transport.Transport) Option {
+	return func(m *multi) {
+		m.transports = append(m.transports, transport...)
+	}
+}
+
+// WithListenTransport allows you to specify an optional listening transport.
+func WithListenTransport(transport transport.Transport) Option {
+	return func(m *multi) {
+		m.listen = transport
+	}
+}

--- a/transport/multi/multi_test.go
+++ b/transport/multi/multi_test.go
@@ -1,0 +1,127 @@
+package multi_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/micro/go-micro/transport"
+	"github.com/micro/go-micro/transport/mock"
+	"github.com/micro/go-plugins/transport/multi"
+)
+
+type deadTransport struct{}
+
+func (f *deadTransport) Dial(addr string, opts ...transport.DialOption) (client transport.Client, err error) {
+	return nil, errors.New("Connection refused")
+}
+
+func (f *deadTransport) Listen(addr string, opts ...transport.ListenOption) (transport.Listener, error) {
+	return nil, errors.New("No port found")
+}
+
+func (f *deadTransport) String() string {
+	return "dead"
+}
+
+func emptyListenerCheck(t *testing.T, transport transport.Transport) {
+	t.Helper()
+
+	listener, err := transport.Listen("127.0.0.1")
+	if expect := "Not supported"; err.Error() != expect {
+		t.Errorf("Got %v expected %v", err, expect)
+	}
+
+	if listener != nil {
+		t.Error("Expected nil listener on error")
+	}
+}
+
+func TestNoTransports(t *testing.T) {
+	transport := multi.NewTransport()
+
+	emptyListenerCheck(t, transport)
+
+	conn, err := transport.Dial("127.0.0.1")
+	if expect := "No transports provided"; err.Error() != expect {
+		t.Errorf("Got %v expected %v", err, expect)
+	}
+
+	if conn != nil {
+		t.Error("expected nil connection on error")
+	}
+}
+
+func TestNoSuccessfulTransports(t *testing.T) {
+	transport := multi.NewTransport(
+		multi.WithTransports(
+			&deadTransport{},
+			&deadTransport{},
+		),
+	)
+
+	emptyListenerCheck(t, transport)
+
+	conn, err := transport.Dial("127.0.0.1")
+	if expect := "Connection refused"; err.Error() != expect {
+		t.Errorf("Got %v expected %v", err, expect)
+	}
+
+	if conn != nil {
+		t.Error("expected nil connection on error")
+	}
+}
+
+func TestSuccessfulTransports(t *testing.T) {
+	mt := mock.NewTransport()
+
+	l, _ := mt.Listen("127.0.0.1:9999")
+	go l.Accept(func(sock transport.Socket) {
+		sock.Close()
+	})
+	defer l.Close()
+
+	transport := multi.NewTransport(
+		multi.WithTransports(
+			&deadTransport{},
+			mt,
+		),
+	)
+
+	emptyListenerCheck(t, transport)
+
+	conn, err := transport.Dial("127.0.0.1:9999")
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+
+	if conn == nil {
+		t.Error("Expected connection to not be nil")
+	}
+
+	conn.Close()
+}
+
+func TestListnerTransport(t *testing.T) {
+	transport := multi.NewTransport(
+		multi.WithListenTransport(mock.NewTransport()),
+	)
+
+	listener, err := transport.Listen("127.0.0.1")
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+
+	if listener == nil {
+		t.Error("Expected listener to not be nil")
+	}
+
+	listener.Close()
+}
+
+func TestString(t *testing.T) {
+	transport := multi.NewTransport()
+
+	if expect, got := "multi", transport.String(); expect != got {
+		t.Errorf("Expected %q got %q", expect, got)
+	}
+}


### PR DESCRIPTION
Permit trying multiple transports in a given order.

eg:
```go
    c := client.NewClient(
        client.Transport(
            multi.NewTransport(
                multi.WithTransports(
                    transport.NewTransport(transport.Secure(true)),
		    transport.NewTransport(transport.Secure(false)),
                ),
            ),
        ),
    )
```