### PR TITLE
feat for grpc and http plugins

### DIFF
--- a/client/grpc/codec.go
+++ b/client/grpc/codec.go
@@ -1,10 +1,10 @@
 package grpc
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/json-iterator/go"
 	"github.com/micro/go-micro/codec"
 	"github.com/micro/go-micro/codec/jsonrpc"
 	"github.com/micro/go-micro/codec/protorpc"
@@ -33,7 +33,19 @@ var (
 		"application/proto-rpc":    protorpc.NewCodec,
 		"application/octet-stream": protorpc.NewCodec,
 	}
+
+	json = jsoniter.ConfigCompatibleWithStandardLibrary
 )
+
+// UseNumber fix unmarshal Number(8234567890123456789) to interface(8.234567890123457e+18)
+func UseNumber() {
+	json = jsoniter.Config{
+		UseNumber:              true,
+		EscapeHTML:             true,
+		SortMapKeys:            true,
+		ValidateJsonRawMessage: true,
+	}.Froze()
+}
 
 func (protoCodec) Marshal(v interface{}) ([]byte, error) {
 	return proto.Marshal(v.(proto.Message))

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -276,6 +276,10 @@ func (g *grpcServer) processRequest(t transport.ServerTransport, stream *transpo
 				}
 			case transport.ConnectionError:
 				// Nothing to do here.
+			case interface{ GRPCStatus() *status.Status }:
+				if err := t.WriteStatus(stream, err.GRPCStatus()); err != nil {
+					log.Logf("grpc: Server.processUnaryRPC failed to write status %v", err)
+				}
 			default:
 				panic(fmt.Sprintf("grpc: Unexpected error (%T) from recvMsg: %v", err, err))
 			}


### PR DESCRIPTION
- add http server log, inspired by grpc server plugin
- grpc json unmarshal can use number, fix unmarshal Number(8234567890123456789) to interface(8.234567890123457e+18)
- catch grpc status error, this error happen when node grpc client request go-micro grpc server