### PR TITLE
Disable certificate checks for kubernetes

### DIFF
--- a/registry/kubernetes/client/client.go
+++ b/registry/kubernetes/client/client.go
@@ -64,7 +64,9 @@ func detectNamespace() (string, error) {
 // NewClientByHost sets up a client by host
 func NewClientByHost(host string) Kubernetes {
 	tr := &http.Transport{
-		TLSClientConfig:    &tls.Config{},
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
 		DisableCompression: true,
 	}
 


### PR DESCRIPTION
As kubernetes generates its own SSL certificate and CA certificate, a client won't be able to connect to kubernetes registry API. One solution could be shipping the CA certificate to the client but when the CA cert expires there is no way to get the new one. 

This change will remove certificate checks, which allows a client to always be able to register in kubernetes service registry. It is critical since if this process doesn't succeed the client service will shutdown. Besides a MitM attack, which TLS is protecting against of, inside a k8s cluster does not make any sense.

There are several issues at k8s repo about TLS certificates and feature requests for allowing certs from a valid and known CA, but they are not willing to implement it. For instance: [https://github.com/kubernetes/kubernetes/issues/61572].