### PR TITLE
Leave the nats broker in a reusable state

### DIFF
--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -109,6 +109,7 @@ func (n *nbroker) Connect() error {
 
 func (n *nbroker) Disconnect() error {
 	n.conn.Close()
+	n.conn = nil
 	return nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/micro/go-plugins/issues/218