### PR TITLE
Rebase with upstream (c944c95)

### DIFF
--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -26,6 +26,10 @@ import (
 	gmetadata "github.com/micro/grpc-go/metadata"
 )
 
+const (
+	defaultMaxMsgSize = 1024 * 1024 * 10 // use 10MB as the default message size limit
+)
+
 type grpcClient struct {
 	once sync.Once
 	opts client.Options
@@ -96,7 +100,7 @@ func (g *grpcClient) call(ctx context.Context, address string, req client.Reques
 
 	var grr error
 
-	cc, err := g.pool.getConn(address, grpc.WithCodec(cf), grpc.WithTimeout(opts.DialTimeout), g.secure())
+	cc, err := g.pool.getConn(address, grpc.WithCodec(cf), grpc.WithTimeout(opts.DialTimeout), g.secure(), grpc.WithMaxMsgSize(defaultMaxMsgSize))
 	if err != nil {
 		return errors.InternalServerError("go.micro.client", fmt.Sprintf("Error sending request: %v", err))
 	}

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -625,7 +625,9 @@ func (g *grpcServer) Register() error {
 	}
 
 	// create registry options
-	rOpts := []registry.RegisterOption{registry.RegisterTTL(config.RegisterTTL)}
+	rOpts := []registry.RegisterOption{
+		registry.RegisterTTL(config.RegisterTTL),
+	}
 
 	if err := config.Registry.Register(service, rOpts...); err != nil {
 		return err

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	defaultMaxMsgSize  = 1024 * 1024 * 4 // use 4MB as the default message size limit
+	defaultMaxMsgSize  = 1024 * 1024 * 10 // use 10MB as the default message size limit
 	defaultContentType = "application/grpc"
 )
 


### PR DESCRIPTION
Many of our previous patch conflicts with upstream, especially on handling
getConn() and release() on grpc client.

The safest way is only to pick the reasonable patches.

Changes:

341ee56 (Shulhan, 6 months ago)
   server/grpc: add option to register with TCP check

0d50ecb (Sakti Dwi Cahyono, 8 months ago)
   client/grpc: change default max msg size from 4MB to 10MB

   Signed-off-by: Shulhan <ms@kilabit.info>

837d3cc (Sakti Dwi Cahyono, 9 months ago)
   server/grpc: change default MaxMsgSize to 10MB

   Signed-off-by: Shulhan <ms@kilabit.info>