### PR TITLE
gzip middleware fails with Content-Length header

### DIFF
--- a/micro/gzip/gzip.go
+++ b/micro/gzip/gzip.go
@@ -59,6 +59,11 @@ func (g *gzipper) String() string {
 	return "gzip"
 }
 
+func (w gzipWriter) WriteHeader(code int) {
+	w.Header().Del("Content-Length")
+	w.ResponseWriter.WriteHeader(code)
+}
+
 func (w gzipWriter) Write(b []byte) (int, error) {
 	return w.Writer.Write(b)
 }


### PR DESCRIPTION
If Content-Length header is set, gzip probably writes the wrong number of bytes. We should delete the Content-Length header prior to writing the headers on a gzipped response.

See [https://github.com/golang/go/issues/14975](url) for more context.