### PR TITLE
Addition of steering strategy.

### DIFF
--- a/selector/steer/README.md
+++ b/selector/steer/README.md
@@ -1,0 +1,38 @@
+# Steer selector
+
+The Steer selector strategy should steer all requests for the given entropy to a single node for the given key, or if that node is failing, a consistent second-choice etc.
+
+It tries to consistently steer all requests for a given set of entropy to a single instance to improve caching memory efficiency.
+
+It should steer all requests for the given entropy, regardless of source service, to a single node, or if that node is failing, a consistent second-choice, etc.
+
+This differs from a filter based selector in that the input set of nodes is not restricted, but rather the entire available set of nodes are processed in a preferential ordering.
+
+# Re-balancing requests
+
+When a new node appears, it will get a fair share of requests randomly allocated from across the existing services as the new node will then be higher scoring for approximately `1/count(nodes)` of the ids.
+
+Similarly, when a node disappears, its load will get fairly redistributed amongst the existing remaining nodes.
+
+# Benefits
+
+This benefits us in that memory can be more optimally used by trying to target requests that have support for caching to servers that are more likely to have that data already, whilst not requiring all servers to have all data for everything cached.
+
+Over time, this results in overall memory savings where one is running multiple services, whist still allowing for fractional re-balancing with auto-scaling and unexpected node failure/replacement, without resorting to a more rigid sharding type strategy.
+
+# Usage
+
+This method is a call option, which can be passed into client RPC requests.
+
+## Example
+
+```go
+rsp, err := myClient.ClientCall(
+    ctx,
+    &ClientCallRequest{
+    	//...
+        SomeID: id,
+    },
+    steer.Strategy(id),
+)
+```

--- a/selector/steer/steer.go
+++ b/selector/steer/steer.go
@@ -1,0 +1,77 @@
+package steer
+
+import (
+	"strings"
+
+	"github.com/micro/go-micro/client"
+	"github.com/micro/go-micro/registry"
+	"github.com/micro/go-micro/selector"
+	"github.com/minio/highwayhash"
+)
+
+// zeroKey is the base key for all hashes, it is 32 zeros.
+var zeroKey [32]byte
+
+// Strategy returns a call option which tries to consistently steer all requests for a given set of entropy to a
+// single instance to improve memory efficiency where instances are caching data.
+//
+// This is the preferred usage as it gives the ultimate flexibility for determining the entropy used.
+//
+// Usage:
+//    `myClient.MyCall(ctx, req, steer.Strategy(req.ID))`
+func Strategy(entropy ...string) client.CallOption {
+	return client.WithSelectOption(NewSelector(entropy))
+}
+
+// NewSelector returns a `SelectOption` that directs all request according to the given `entropy`.
+func NewSelector(entropy []string) selector.SelectOption {
+	return selector.WithStrategy(func(services []*registry.Service) selector.Next {
+		return Next(entropy, services)
+	})
+}
+
+// Next returns a `Next` function which returns the next highest scoring node.
+func Next(entropy []string, services []*registry.Service) selector.Next {
+	possibleNodes, scores := ScoreNodes(entropy, services)
+
+	return func() (*registry.Node, error) {
+		var best uint64
+		pos := -1
+
+		// Find the best scoring node from those available.
+		for i, score := range scores {
+			if score >= best && possibleNodes[i] != nil {
+				best = score
+				pos = i
+			}
+		}
+
+		if pos < 0 {
+			// There was no node found.
+			return nil, nil
+		}
+
+		// Choose this node and set it's score to zero to stop it being selected again.
+		node := possibleNodes[pos]
+		possibleNodes[pos] = nil
+		scores[pos] = 0
+		return node, nil
+	}
+}
+
+// ScoreNodes returns a score for each node found in the given services.
+func ScoreNodes(entropy []string, services []*registry.Service) (possibleNodes []*registry.Node, scores []uint64) {
+	// Generate a base hashing key based off the supplied entropy values.
+	key := highwayhash.Sum([]byte(strings.Join(entropy, ":")), zeroKey[:])
+
+	// Get all the possible nodes for the services, and assign a hash-based score to each of them.
+	for _, s := range services {
+		for _, n := range s.Nodes {
+			// Use the base key from above to calculate a derivative 64 bit hash number based off the instance ID.
+			score := highwayhash.Sum64([]byte(n.Id), key[:])
+			scores = append(scores, score)
+			possibleNodes = append(possibleNodes, n)
+		}
+	}
+	return
+}

--- a/selector/steer/steer_test.go
+++ b/selector/steer/steer_test.go
@@ -1,0 +1,155 @@
+package steer_test
+
+import (
+	"testing"
+
+	"github.com/micro/go-micro/client"
+	"github.com/micro/go-micro/registry"
+	"github.com/micro/go-micro/selector"
+	"github.com/micro/go-plugins/selector/steer"
+)
+
+func TestSteer(t *testing.T) {
+	type args struct {
+		entropy []string
+		nodes   []*registry.Node
+		count   int
+	}
+
+	type test struct {
+		name string
+		args args
+		want *registry.Node
+	}
+
+	node1 := &registry.Node{
+		Id: "1",
+	}
+
+	node2 := &registry.Node{
+		Id: "2",
+	}
+
+	node3 := &registry.Node{
+		Id: "3",
+	}
+
+	nodes := func(n ...*registry.Node) []*registry.Node {
+		return n
+	}
+
+	tests := []test{
+		{
+			name: "test single",
+			args: args{
+				entropy: []string{"a"},
+				nodes:   nodes(node1),
+				count:   1,
+			},
+			want: node1,
+		},
+		{
+			name: "test two nodes",
+			args: args{
+				entropy: []string{"c"},
+				nodes:   nodes(node1, node2),
+				count:   1,
+			},
+			want: node2,
+		},
+		{
+			name: "test three nodes",
+			args: args{
+				entropy: []string{"b"},
+				nodes:   nodes(node1, node2, node3),
+				count:   1,
+			},
+			want: node3,
+		},
+		{
+			name: "test three nodes two params",
+			args: args{
+				entropy: []string{"a", "a"},
+				nodes:   nodes(node1, node2, node3),
+				count:   1,
+			},
+			want: node1,
+		},
+		{
+			name: "test three nodes two params two cycles",
+			args: args{
+				entropy: []string{"a", "a"},
+				nodes:   nodes(node1, node2, node3),
+				count:   2,
+			},
+			want: node2,
+		},
+		{
+			name: "test three nodes two params three cycles",
+			args: args{
+				entropy: []string{"a", "a"},
+				nodes:   nodes(node1, node2, node3),
+				count:   3,
+			},
+			want: node3,
+		},
+		{
+			name: "test three nodes two params four cycles",
+			args: args{
+				entropy: []string{"a", "a"},
+				nodes:   nodes(node1, node2, node3),
+				count:   4,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := steer.Option(tt.args.entropy...)
+			next := getNext(fn, tt.args.nodes)
+
+			if next == nil {
+				t.Error("got nil next")
+				return
+			}
+
+			var err error
+			var got *registry.Node
+			for i := 0; i < tt.args.count; i++ {
+				got, err = next()
+				if err != nil {
+					t.Errorf("got error with next %v", err)
+					return
+				}
+			}
+
+			if got != tt.want {
+				t.Errorf("Steer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func getNext(fn client.CallOption, nodes []*registry.Node) selector.Next {
+	co := &client.CallOptions{}
+	fn(co)
+
+	if len(co.SelectOptions) != 1 {
+		return nil
+	}
+
+	opt := co.SelectOptions[0]
+
+	so := &selector.SelectOptions{}
+	opt(so)
+
+	if so.Strategy == nil {
+		return nil
+	}
+
+	return so.Strategy([]*registry.Service{
+		{
+			Nodes: nodes,
+		},
+	})
+}


### PR DESCRIPTION
This PR is to add a new request steering strategy which can be used as an RPC call level option to direct requests to a preferentially ordered list of nodes.

We are using this strategy to direct certain requests at one of several services when we have data that needs to be loaded and kept cached on these services.

This helps to reduce our overall memory consumption by allowing us to not have to have all the things cached on all the services, but only the things that the given service is dealing with.