### PR TITLE
fix(broker-rabbitmq): Add nack for RabbitMQ

### DIFF
--- a/broker/rabbitmq/connection.go
+++ b/broker/rabbitmq/connection.go
@@ -19,6 +19,7 @@ var (
 	DefaultRabbitURL      = "amqp://guest:guest@127.0.0.1:5672"
 	DefaultPrefetchCount  = 0
 	DefaultPrefetchGlobal = false
+	DefaultRequeueOnError = false
 
 	dial    = amqp.Dial
 	dialTLS = amqp.DialTLS

--- a/broker/rabbitmq/options.go
+++ b/broker/rabbitmq/options.go
@@ -11,6 +11,7 @@ type headersKey struct{}
 type prefetchCountKey struct{}
 type prefetchGlobalKey struct{}
 type exchangeKey struct{}
+type requeueOnErrorKey struct{}
 
 // DurableQueue creates a durable queue when subscribing.
 func DurableQueue() broker.SubscribeOption {
@@ -59,5 +60,15 @@ func PrefetchGlobal() broker.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, prefetchGlobalKey{}, true)
+	}
+}
+
+// RequeueOnError calls Nack(muliple:false, requeue:true) on amqp delivery when handler returns error
+func RequeueOnError() broker.Option {
+	return func(o *broker.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, requeueOnErrorKey{}, true)
 	}
 }

--- a/broker/rabbitmq/options.go
+++ b/broker/rabbitmq/options.go
@@ -33,6 +33,16 @@ func Headers(h map[string]interface{}) broker.SubscribeOption {
 	}
 }
 
+// RequeueOnError calls Nack(muliple:false, requeue:true) on amqp delivery when handler returns error
+func RequeueOnError() broker.SubscribeOption {
+	return func(o *broker.SubscribeOptions) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, requeueOnErrorKey{}, true)
+	}
+}
+
 // Exchange is an option to set the Exchange
 func Exchange(e string) broker.Option {
 	return func(o *broker.Options) {
@@ -60,15 +70,5 @@ func PrefetchGlobal() broker.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, prefetchGlobalKey{}, true)
-	}
-}
-
-// RequeueOnError calls Nack(muliple:false, requeue:true) on amqp delivery when handler returns error
-func RequeueOnError() broker.Option {
-	return func(o *broker.Options) {
-		if o.Context == nil {
-			o.Context = context.Background()
-		}
-		o.Context = context.WithValue(o.Context, requeueOnErrorKey{}, true)
 	}
 }


### PR DESCRIPTION
This fixes problem when handler returns error and message stucks in prefetch.
Nack calls only when `AutoAck` option is set to false and manual acknowledge is required. 