### PR TITLE
client/grpc: add an option to set maximum received message size

### DIFF
--- a/client/grpc/options.go
+++ b/client/grpc/options.go
@@ -9,8 +9,15 @@ import (
 	"github.com/micro/grpc-go/encoding"
 )
 
+var (
+	// DefaultMaxRecvMsgSize maximum message that client can receive
+	// (4 MB).
+	DefaultMaxRecvMsgSize = 1024 * 1024 * 4
+)
+
 type codecsKey struct{}
 type tlsAuth struct{}
+type maxRecvMsgSizeKey struct{}
 
 // gRPC Codec to be used to encode/decode requests for a given content type
 func Codec(contentType string, c encoding.Codec) client.Option {
@@ -34,5 +41,17 @@ func AuthTLS(t *tls.Config) client.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, tlsAuth{}, t)
+	}
+}
+
+//
+// MaxRecvMsgSize set the maximum size of message that client can receive.
+//
+func MaxRecvMsgSize(s int) client.Option {
+	return func(o *client.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, maxRecvMsgSizeKey{}, s)
 	}
 }


### PR DESCRIPTION
The default maximum received message size is 4 MB.

Resolve #132.