### PR TITLE
server/grpc: add option to set maximum message size

### DIFF
--- a/server/grpc/options.go
+++ b/server/grpc/options.go
@@ -15,6 +15,7 @@ import (
 
 type codecsKey struct{}
 type tlsAuth struct{}
+type maxMsgSizeKey struct{}
 
 // gRPC Codec to be used to encode/decode requests for a given content type
 func Codec(contentType string, c encoding.Codec) server.Option {
@@ -38,6 +39,19 @@ func AuthTLS(t *tls.Config) server.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, tlsAuth{}, t)
+	}
+}
+
+//
+// MaxMsgSize set the maximum message in bytes the server can receive and
+// send.  Default maximum message size is 4 MB.
+//
+func MaxMsgSize(s int) server.Option {
+	return func(o *server.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, maxMsgSizeKey{}, s)
 	}
 }
 


### PR DESCRIPTION
The message size limit affect on receive and send operations.

Default maximum message is equal with upstream (google.golang.com/grpc),
which is 4 MB.