### PR TITLE
Add subscription option to use existing subscription for google pubsub broker

### DIFF
--- a/broker/googlepubsub/googlepubsub.go
+++ b/broker/googlepubsub/googlepubsub.go
@@ -169,9 +169,14 @@ func (b *pubsubBroker) Publish(topic string, msg *broker.Message, opts ...broker
 
 // Subscribe registers a subscription to the given topic against the google pubsub api
 func (b *pubsubBroker) Subscribe(topic string, h broker.Handler, opts ...broker.SubscribeOption) (broker.Subscriber, error) {
+	queueName := "q-" + uuid.New().String()
+	if subscriptionName, ok := b.options.Context.Value(subscriptionName{}).(string); ok {
+		queueName = subscriptionName
+	}
+
 	options := broker.SubscribeOptions{
 		AutoAck: true,
-		Queue:   "q-" + uuid.New().String(),
+		Queue:   queueName,
 		Context: b.options.Context,
 	}
 

--- a/broker/googlepubsub/options.go
+++ b/broker/googlepubsub/options.go
@@ -20,6 +20,8 @@ type createSubscription struct{}
 
 type deleteSubscription struct{}
 
+type subscriptionName struct{}
+
 // ClientOption is a broker Option which allows google pubsub client options to be
 // set for the client
 func ClientOption(c ...option.ClientOption) broker.Option {
@@ -86,3 +88,16 @@ func MaxExtension(d time.Duration) broker.SubscribeOption {
 		o.Context = context.WithValue(o.Context, maxExtensionKey{}, d)
 	}
 }
+
+// SubscriptionName is the name of existing subscription. This could be used
+// when user wants to use the subscription they've made before.
+func SubscriptionName(name string) broker.SubscribeOption {
+	return func(o *broker.SubscribeOptions) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+
+		o.Context = context.WithValue(o.Context, subscriptionName{}, name)
+	}
+}
+


### PR DESCRIPTION
# Background
In latest go-plugins, the `Subscribe(...)` function in `googlepubsub.go` can't use the subscription that we already have (this subscription might be created before or already exists before), but it will always create a new google pubsub subscription to a defined google pubsub topic. 

To solve this issue, I added a small changes and a new option so that a user can specify whether he/she wants to create a new google pubsub subscription or to use the existing google pubsub subscription they already made.

This changes included:
* A new subscription option
```
func SubscriptionName(name string) broker.SubscribeOption
```

* Changes on the implementation of `Subscribe(..)` method.
