### PR TITLE
child node path watched by zookeeper is wrong when zw.wo.Service is set

### DIFF
--- a/registry/zookeeper/util.go
+++ b/registry/zookeeper/util.go
@@ -25,6 +25,10 @@ func nodePath(s, id string) string {
 	return path.Join(prefix, service, node)
 }
 
+func childPath(parent, child string) string {
+	return path.Join(parent, strings.Replace(child, "/", "-", -1))
+}
+
 func servicePath(s string) string {
 	return path.Join(prefix, strings.Replace(s, "/", "-", -1))
 }

--- a/registry/zookeeper/watcher.go
+++ b/registry/zookeeper/watcher.go
@@ -163,7 +163,7 @@ func (zw *zookeeperWatcher) watch() {
 
 	//watch every service
 	for _, service := range services {
-		sPath := servicePath(service)
+		sPath := childPath(watchPath, service)
 		go zw.watchDir(sPath, respChan)
 		children, _, err := zw.client.Children(sPath)
 		if err != nil {


### PR DESCRIPTION
 child node path watched by zookeeper is wrong when zw.wo.Service is set. 
`zk: node does not exist`.

prefix of this child node is `watchPath` not `prefix`.