### PR TITLE
refactor: add grpc broker to cmd

### DIFF
--- a/broker/grpc/grpc.go
+++ b/broker/grpc/grpc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/micro/go-log"
 	"github.com/micro/go-micro/broker"
+	"github.com/micro/go-micro/cmd"
 	merr "github.com/micro/go-micro/errors"
 	"github.com/micro/go-micro/registry"
 	proto "github.com/micro/go-plugins/broker/grpc/proto"

--- a/broker/grpc/grpc.go
+++ b/broker/grpc/grpc.go
@@ -69,6 +69,8 @@ var (
 
 func init() {
 	rand.Seed(time.Now().Unix())
+
+	cmd.DefaultBrokers["grpc"] = NewBroker
 }
 
 func newConfig(config *tls.Config) *tls.Config {


### PR DESCRIPTION
**Problem**: "_Broker grpc not found_" error when trying to use the build pattern to create a grpc service with grpc broker
**Solution**: add `grpc` to `cmd.DefaultBrokers` on `init`