### PR TITLE
client/grpc: add option to set maximum send message size

### DIFF
--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -93,12 +93,16 @@ func (g *grpcClient) call(ctx context.Context, address string, req client.Reques
 	}
 
 	maxRecvMsgSize := g.maxRecvMsgSizeValue()
+	maxSendMsgSize := g.maxSendMsgSizeValue()
 
 	var grr error
 
 	cc, err := g.pool.getConn(address, grpc.WithDefaultCallOptions(grpc.CallCustomCodec(cf)),
 		grpc.WithTimeout(opts.DialTimeout), g.secure(),
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxRecvMsgSize)))
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxRecvMsgSize),
+			grpc.MaxCallSendMsgSize(maxSendMsgSize),
+		))
 	if err != nil {
 		return errors.InternalServerError("go.micro.client", fmt.Sprintf("Error sending request: %v", err))
 	}
@@ -184,6 +188,17 @@ func (g *grpcClient) maxRecvMsgSizeValue() int {
 	v := g.opts.Context.Value(maxRecvMsgSizeKey{})
 	if v == nil {
 		return DefaultMaxRecvMsgSize
+	}
+	return v.(int)
+}
+
+func (g *grpcClient) maxSendMsgSizeValue() int {
+	if g.opts.Context == nil {
+		return DefaultMaxSendMsgSize
+	}
+	v := g.opts.Context.Value(maxSendMsgSizeKey{})
+	if v == nil {
+		return DefaultMaxSendMsgSize
 	}
 	return v.(int)
 }

--- a/client/grpc/options.go
+++ b/client/grpc/options.go
@@ -13,11 +13,16 @@ var (
 	// DefaultMaxRecvMsgSize maximum message that client can receive
 	// (4 MB).
 	DefaultMaxRecvMsgSize = 1024 * 1024 * 4
+
+	// DefaultMaxSendMsgSize maximum message that client can send
+	// (4 MB).
+	DefaultMaxSendMsgSize = 1024 * 1024 * 4
 )
 
 type codecsKey struct{}
 type tlsAuth struct{}
 type maxRecvMsgSizeKey struct{}
+type maxSendMsgSizeKey struct{}
 
 // gRPC Codec to be used to encode/decode requests for a given content type
 func Codec(contentType string, c encoding.Codec) client.Option {
@@ -53,5 +58,17 @@ func MaxRecvMsgSize(s int) client.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, maxRecvMsgSizeKey{}, s)
+	}
+}
+
+//
+// MaxSendMsgSize set the maximum size of message that client can send.
+//
+func MaxSendMsgSize(s int) client.Option {
+	return func(o *client.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, maxSendMsgSizeKey{}, s)
 	}
 }


### PR DESCRIPTION
Continuing patch 99db9b59, where grpc service can received message larger
than their default value (4MB); this commit add option to change the
message size that gRPC client can send.