### PR TITLE
wrapper: prometheus attach labels to all metrics

### DIFF
--- a/wrapper/monitoring/prometheus/prometheus_test.go
+++ b/wrapper/monitoring/prometheus/prometheus_test.go
@@ -87,6 +87,10 @@ func TestPrometheusMetrics(t *testing.T) {
 
 	metric := findMetricByName(list, dto.MetricType_SUMMARY, "micro_upstream_latency_microseconds")
 
+	if metric == nil || metric.Metric == nil || len(metric.Metric) == 0 {
+		t.Fatalf("no metrics returned")
+	}
+
 	for _, v := range metric.Metric[0].Label {
 		switch *v.Name {
 		case "micro_dc":


### PR DESCRIPTION
this allow to filter by label all metrics, not only own but also default

Signed-off-by: Vasiliy Tolstov <v.tolstov@unistack.org>