### PR TITLE
Added support for RabbitMQ External Authentication

### DIFF
--- a/broker/rabbitmq/auth.go
+++ b/broker/rabbitmq/auth.go
@@ -1,0 +1,12 @@
+package rabbitmq
+
+type ExternalAuthentication struct {
+}
+
+func (auth *ExternalAuthentication) Mechanism() string {
+	return "EXTERNAL"
+}
+
+func (auth *ExternalAuthentication) Response() string {
+	return ""
+}

--- a/broker/rabbitmq/connection_test.go
+++ b/broker/rabbitmq/connection_test.go
@@ -37,34 +37,35 @@ func TestTryToConnectTLS(t *testing.T) {
 		err = errors.New("stop connect here")
 	)
 
-	dial = func(_ string) (*amqp.Connection, error) {
+	dialConfig = func(_ string, c amqp.Config) (*amqp.Connection, error) {
+
+		if c.TLSClientConfig != nil {
+			dialTLSCount++
+			return nil, err
+		}
+
 		dialCount++
 		return nil, err
 	}
 
-	dialTLS = func(_ string, _ *tls.Config) (*amqp.Connection, error) {
-		dialTLSCount++
-		return nil, err
-	}
-
 	testcases := []struct {
-		title     string
-		url       string
-		secure    bool
-		tlsConfig *tls.Config
-		wantTLS   bool
+		title      string
+		url        string
+		secure     bool
+		amqpConfig *amqp.Config
+		wantTLS    bool
 	}{
 		{"unsecure url, secure false, no tls config", "amqp://example.com", false, nil, false},
 		{"secure url, secure false, no tls config", "amqps://example.com", false, nil, true},
 		{"unsecure url, secure true, no tls config", "amqp://example.com", true, nil, true},
-		{"unsecure url, secure false, tls config", "amqp://example.com", false, &tls.Config{}, true},
+		{"unsecure url, secure false, tls config", "amqp://example.com", false, &amqp.Config{TLSClientConfig: &tls.Config{}}, true},
 	}
 
 	for _, test := range testcases {
 		dialCount, dialTLSCount = 0, 0
 
 		conn := newRabbitMQConn("exchange", []string{test.url}, 0, false)
-		conn.tryConnect(test.secure, test.tlsConfig)
+		conn.tryConnect(test.secure, test.amqpConfig)
 
 		have := dialCount
 		if test.wantTLS {

--- a/broker/rabbitmq/options.go
+++ b/broker/rabbitmq/options.go
@@ -13,6 +13,7 @@ type prefetchGlobalKey struct{}
 type exchangeKey struct{}
 type requeueOnErrorKey struct{}
 type deliveryMode struct{}
+type externalAuth struct{}
 
 // DurableQueue creates a durable queue when subscribing.
 func DurableQueue() broker.SubscribeOption {
@@ -47,6 +48,10 @@ func PrefetchGlobal() broker.Option {
 // DeliveryMode sets a delivery mode for publishing
 func DeliveryMode(value uint8) broker.PublishOption {
 	return setPublishOption(deliveryMode{}, value)
+}
+
+func ExternalAuth() broker.Option {
+	return setBrokerOption(externalAuth{}, ExternalAuthentication{})
 }
 
 type subscribeContextKey struct{}

--- a/broker/rabbitmq/rabbitmq.go
+++ b/broker/rabbitmq/rabbitmq.go
@@ -259,7 +259,16 @@ func (r *rbroker) Connect() error {
 	if r.conn == nil {
 		r.conn = newRabbitMQConn(r.getExchange(), r.opts.Addrs, r.getPrefetchCount(), r.getPrefetchGlobal())
 	}
-	return r.conn.Connect(r.opts.Secure, r.opts.TLSConfig)
+
+	conf := defaultAmqpConfig
+
+	if auth, ok := r.opts.Context.Value(externalAuth{}).(ExternalAuthentication); ok {
+		conf.SASL = []amqp.Authentication{&auth}
+	}
+
+	conf.TLSClientConfig = r.opts.TLSConfig
+
+	return r.conn.Connect(r.opts.Secure, &conf)
 }
 
 func (r *rbroker) Disconnect() error {


### PR DESCRIPTION
This adds support for RabbitMQ External Authenthication (See https://www.rabbitmq.com/authentication.html) through a `broker.Option`

Since the authentication configuration is a field on the `amqp.Config` which is outside the `tls.Config` which was passed in, in most connect methods, I changed their signature to take in an `amqp.Confg` instead allowing for easier future support of other rabbit features.

To be able to set the `amqp.Config` the dial library now calls `amqp.DialConfig` instead and tests have been changed accordingly.