### PR TITLE
Rabbitmq durableexchange

### DIFF
--- a/broker/rabbitmq/channel.go
+++ b/broker/rabbitmq/channel.go
@@ -72,6 +72,18 @@ func (r *rabbitMQChannel) DeclareExchange(exchange string) error {
 	)
 }
 
+func (r *rabbitMQChannel) DeclareDurableExchange(exchange string) error {
+	return r.channel.ExchangeDeclare(
+		exchange, // name
+		"topic",  // kind
+		true,     // durable
+		false,    // autoDelete
+		false,    // internal
+		false,    // noWait
+		nil,      // args
+	)
+}
+
 func (r *rabbitMQChannel) DeclareQueue(queue string) error {
 	_, err := r.channel.QueueDeclare(
 		queue, // name

--- a/broker/rabbitmq/connection.go
+++ b/broker/rabbitmq/connection.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	DefaultExchange = rabbitMQExchange{
+	DefaultExchange = exchange{
 		name: "micro",
 	}
 	DefaultRabbitURL      = "amqp://guest:guest@127.0.0.1:5672"
@@ -43,7 +43,7 @@ type rabbitMQConn struct {
 	Connection      *amqp.Connection
 	Channel         *rabbitMQChannel
 	ExchangeChannel *rabbitMQChannel
-	exchange        rabbitMQExchange
+	exchange        exchange
 	url             string
 	prefetchCount   int
 	prefetchGlobal  bool
@@ -55,12 +55,12 @@ type rabbitMQConn struct {
 	waitConnection chan struct{}
 }
 
-type rabbitMQExchange struct {
+type exchange struct {
 	name    string
 	durable bool
 }
 
-func newRabbitMQConn(exchange rabbitMQExchange, urls []string, prefetchCount int, prefetchGlobal bool) *rabbitMQConn {
+func newRabbitMQConn(ex exchange, urls []string, prefetchCount int, prefetchGlobal bool) *rabbitMQConn {
 	var url string
 
 	if len(urls) > 0 && regexp.MustCompile("^amqp(s)?://.*").MatchString(urls[0]) {
@@ -69,12 +69,12 @@ func newRabbitMQConn(exchange rabbitMQExchange, urls []string, prefetchCount int
 		url = DefaultRabbitURL
 	}
 
-	if len(exchange.name) == 0 {
-		exchange = DefaultExchange
+	if len(ex.name) == 0 {
+		ex = DefaultExchange
 	}
 
 	ret := &rabbitMQConn{
-		exchange:       exchange,
+		exchange:       ex,
 		url:            url,
 		prefetchCount:  prefetchCount,
 		prefetchGlobal: prefetchGlobal,

--- a/broker/rabbitmq/connection_test.go
+++ b/broker/rabbitmq/connection_test.go
@@ -22,7 +22,7 @@ func TestNewRabbitMQConnURL(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		conn := newRabbitMQConn("exchange", test.urls, 0, false)
+		conn := newRabbitMQConn(rabbitMQExchange{name: "exchange"}, test.urls, 0, false)
 
 		if have, want := conn.url, test.want; have != want {
 			t.Errorf("%s: invalid url, want %q, have %q", test.title, want, have)
@@ -64,7 +64,7 @@ func TestTryToConnectTLS(t *testing.T) {
 	for _, test := range testcases {
 		dialCount, dialTLSCount = 0, 0
 
-		conn := newRabbitMQConn("exchange", []string{test.url}, 0, false)
+		conn := newRabbitMQConn(rabbitMQExchange{name: "exchange"}, []string{test.url}, 0, false)
 		conn.tryConnect(test.secure, test.amqpConfig)
 
 		have := dialCount
@@ -93,7 +93,7 @@ func TestNewRabbitMQPrefetch(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		conn := newRabbitMQConn("exchange", test.urls, test.prefetchCount, test.prefetchGlobal)
+		conn := newRabbitMQConn(rabbitMQExchange{name: "exchange"}, test.urls, test.prefetchCount, test.prefetchGlobal)
 
 		if have, want := conn.prefetchCount, test.prefetchCount; have != want {
 			t.Errorf("%s: invalid prefetch count, want %d, have %d", test.title, want, have)

--- a/broker/rabbitmq/connection_test.go
+++ b/broker/rabbitmq/connection_test.go
@@ -22,7 +22,7 @@ func TestNewRabbitMQConnURL(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		conn := newRabbitMQConn(rabbitMQExchange{name: "exchange"}, test.urls, 0, false)
+		conn := newRabbitMQConn(exchange{name: "exchange"}, test.urls, 0, false)
 
 		if have, want := conn.url, test.want; have != want {
 			t.Errorf("%s: invalid url, want %q, have %q", test.title, want, have)
@@ -64,7 +64,7 @@ func TestTryToConnectTLS(t *testing.T) {
 	for _, test := range testcases {
 		dialCount, dialTLSCount = 0, 0
 
-		conn := newRabbitMQConn(rabbitMQExchange{name: "exchange"}, []string{test.url}, 0, false)
+		conn := newRabbitMQConn(exchange{name: "exchange"}, []string{test.url}, 0, false)
 		conn.tryConnect(test.secure, test.amqpConfig)
 
 		have := dialCount
@@ -93,7 +93,7 @@ func TestNewRabbitMQPrefetch(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		conn := newRabbitMQConn(rabbitMQExchange{name: "exchange"}, test.urls, test.prefetchCount, test.prefetchGlobal)
+		conn := newRabbitMQConn(exchange{name: "exchange"}, test.urls, test.prefetchCount, test.prefetchGlobal)
 
 		if have, want := conn.prefetchCount, test.prefetchCount; have != want {
 			t.Errorf("%s: invalid prefetch count, want %d, have %d", test.title, want, have)

--- a/broker/rabbitmq/options.go
+++ b/broker/rabbitmq/options.go
@@ -14,10 +14,16 @@ type exchangeKey struct{}
 type requeueOnErrorKey struct{}
 type deliveryMode struct{}
 type externalAuth struct{}
+type durableExchange struct{}
 
 // DurableQueue creates a durable queue when subscribing.
 func DurableQueue() broker.SubscribeOption {
 	return setSubscribeOption(durableQueueKey{}, true)
+}
+
+// DurableExchange is an option to set the Exchange to be durable
+func DurableExchange() broker.SubscribeOption {
+	return setSubscribeOption(durableExchange{}, true)
 }
 
 // Headers adds headers used by the headers exchange

--- a/broker/rabbitmq/options.go
+++ b/broker/rabbitmq/options.go
@@ -22,8 +22,8 @@ func DurableQueue() broker.SubscribeOption {
 }
 
 // DurableExchange is an option to set the Exchange to be durable
-func DurableExchange() broker.SubscribeOption {
-	return setSubscribeOption(durableExchange{}, true)
+func DurableExchange() broker.Option {
+	return setBrokerOption(durableExchange{}, true)
 }
 
 // Headers adds headers used by the headers exchange

--- a/broker/rabbitmq/rabbitmq.go
+++ b/broker/rabbitmq/rabbitmq.go
@@ -163,7 +163,7 @@ func (r *rbroker) Publish(topic string, msg *broker.Message, opts ...broker.Publ
 		return errors.New("connection is nil")
 	}
 
-	return r.conn.Publish(r.conn.exchange, topic, m)
+	return r.conn.Publish(r.conn.exchange.name, topic, m)
 }
 
 func (r *rbroker) Subscribe(topic string, handler broker.Handler, opts ...broker.SubscribeOption) (broker.Subscriber, error) {
@@ -295,11 +295,19 @@ func NewBroker(opts ...broker.Option) broker.Broker {
 	}
 }
 
-func (r *rbroker) getExchange() string {
+func (r *rbroker) getExchange() rabbitMQExchange {
+
+	ex := DefaultExchange
+
 	if e, ok := r.opts.Context.Value(exchangeKey{}).(string); ok {
-		return e
+		ex.name = e
 	}
-	return DefaultExchange
+
+	if d, ok := r.opts.Context.Value(durableExchange{}).(bool); ok {
+		ex.durable = d
+	}
+
+	return ex
 }
 
 func (r *rbroker) getPrefetchCount() int {

--- a/broker/rabbitmq/rabbitmq.go
+++ b/broker/rabbitmq/rabbitmq.go
@@ -295,7 +295,7 @@ func NewBroker(opts ...broker.Option) broker.Broker {
 	}
 }
 
-func (r *rbroker) getExchange() rabbitMQExchange {
+func (r *rbroker) getExchange() exchange {
 
 	ex := DefaultExchange
 


### PR DESCRIPTION
This adds support for making a Durable Exchange in RabbitMQ through a `broker.Option`

Since the method declaring the exchange does not have access to the broker context, I changed the internal exchange call to be a struct which contains both the name and whether the exchange should be durable or not and expose a new `broker.Option` to set that