### PR TITLE
Added support for custom grpc options

### DIFF
--- a/server/grpc/README.md
+++ b/server/grpc/README.md
@@ -19,8 +19,12 @@ import (
 
 func main() {
         service := micro.NewService(
-                micro.Name("greeter"),
+                // This needs to be first as it replaces the underlying server
+                // which causes any configuration set before it
+                // to be discarded
                 micro.Server(grpc.NewServer()),
+                micro.Name("greeter"),
         )
 }
 ```
+**NOTE**: Setting the gRPC server and/or client causes the underlying the server/client to be replaced which causes any previous configuration set on that server/client to be discarded. It is therefore recommended to set gRPC server/client before any other configuration

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -105,6 +105,10 @@ func (g *grpcServer) configure(opts ...server.Option) {
 		gopts = append(gopts, grpc.Creds(creds))
 	}
 
+	if opts := g.getGrpcOptions(); opts != nil {
+		gopts = append(gopts, opts...)
+	}
+
 	g.srv = grpc.NewServer(gopts...)
 }
 
@@ -127,6 +131,26 @@ func (g *grpcServer) getCredentials() credentials.TransportCredentials {
 		}
 	}
 	return nil
+}
+
+func (g *grpcServer) getGrpcOptions() []grpc.ServerOption {
+	if g.opts.Context == nil {
+		return nil
+	}
+
+	v := g.opts.Context.Value(grpcOptions{})
+
+	if v == nil {
+		return nil
+	}
+
+	opts, ok := v.([]grpc.ServerOption)
+
+	if !ok {
+		return nil
+	}
+
+	return opts
 }
 
 func (g *grpcServer) handler(srv interface{}, stream grpc.ServerStream) error {

--- a/server/grpc/options.go
+++ b/server/grpc/options.go
@@ -10,12 +10,14 @@ import (
 	"github.com/micro/go-micro/server"
 	"github.com/micro/go-micro/server/debug"
 	"github.com/micro/go-micro/transport"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding"
 )
 
 type codecsKey struct{}
 type tlsAuth struct{}
 type maxMsgSizeKey struct{}
+type grpcOptions struct{}
 
 // gRPC Codec to be used to encode/decode requests for a given content type
 func Codec(contentType string, c encoding.Codec) server.Option {
@@ -39,6 +41,16 @@ func AuthTLS(t *tls.Config) server.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, tlsAuth{}, t)
+	}
+}
+
+// Options to be used to configure gRPC options
+func Options(opts ...grpc.ServerOption) server.Option {
+	return func(o *server.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, grpcOptions{}, opts)
 	}
 }
 


### PR DESCRIPTION
- Updated grpc README.md to reflect issue with passing server/client options before setting server
- Added custom grpc options support. This also adds support for [grpc middleware](https://github.com/grpc-ecosystem/go-grpc-middleware)