### PR TITLE
repair grpc.Dial error

### DIFF
--- a/broker/grpc/grpc.go
+++ b/broker/grpc/grpc.go
@@ -431,9 +431,10 @@ func (h *grpcBroker) Publish(topic string, msg *broker.Message, opts ...broker.P
 
 		// dial grpc connection
 		c, err := grpc.Dial(fmt.Sprintf("%s:%d", node.Address, node.Port), opts...)
-		if err == nil {
-			return
-		}
+	        if err != nil {
+                   log.Logf(err.Error())
+                   return
+                }
 
 		// publish message
 		proto.NewBrokerClient(c).Publish(context.TODO(), m)

--- a/broker/grpc/grpc.go
+++ b/broker/grpc/grpc.go
@@ -418,7 +418,9 @@ func (h *grpcBroker) Publish(topic string, msg *broker.Message, opts ...broker.P
 		// check if secure is added in metadata
 		if node.Metadata["secure"] == "true" {
 			opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(config)))
-		}
+		} else {
+                        opts = append(opts, grpc.WithInsecure())
+                }
 
 		m := &proto.Message{
 			Topic:  b.Topic,


### PR DESCRIPTION
grpc.Dial needs tls by default

error detail:
grpc: no transport security set (use grpc.WithInsecure() explicitly or set credentials)