### PR TITLE
fix broker.Publication.Ack() panic in kafka

### DIFF
--- a/broker/kafka/options.go
+++ b/broker/kafka/options.go
@@ -50,6 +50,7 @@ func (h *consumerGroupHandler) ConsumeClaim(sess sarama.ConsumerGroupSession, cl
 		if err := h.handler(&publication{
 			m:    &m,
 			t:    msg.Topic,
+			km:   msg,
 			cg:   h.cg,
 			sess: sess,
 		}); err == nil && h.subopts.AutoAck {


### PR DESCRIPTION
broker/kafka/kafka.go: Line:54
func (p *publication) Ack() error {
	p.sess.MarkMessage(p.km, "")
	return nil
}

When missing  p.km ,it will panic 