### PR TITLE
registry/nats: use new repo path

### DIFF
--- a/registry/nats/nats.go
+++ b/registry/nats/nats.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/micro/go-micro/cmd"
 	"github.com/micro/go-micro/registry"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 type natsRegistry struct {

--- a/registry/nats/options.go
+++ b/registry/nats/options.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/micro/go-micro/registry"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 type contextQuorumKey struct{}

--- a/registry/nats/options_test.go
+++ b/registry/nats/options_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-log/log"
 	"github.com/micro/go-micro/registry"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 var addrTestCases = []struct {

--- a/registry/nats/watcher.go
+++ b/registry/nats/watcher.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/micro/go-micro/registry"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 type natsWatcher struct {


### PR DESCRIPTION
Hi @asim, 
I saw you updated a few days ago the url for the nets repo for the broker plugin. This PR updates the repo path for the nats registry plugin.