### PR TITLE
transport/nats: use new repo path

### DIFF
--- a/transport/nats/nats.go
+++ b/transport/nats/nats.go
@@ -13,7 +13,7 @@ import (
 	"github.com/micro/go-micro/codec/json"
 	"github.com/micro/go-micro/server"
 	"github.com/micro/go-micro/transport"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 type ntport struct {

--- a/transport/nats/nats_test.go
+++ b/transport/nats/nats_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-log/log"
 	"github.com/micro/go-micro/server"
 	"github.com/micro/go-micro/transport"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 var addrTestCases = []struct {

--- a/transport/nats/options.go
+++ b/transport/nats/options.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/micro/go-micro/transport"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 type optionsKey struct{}


### PR DESCRIPTION
Similar to #340, this PR updates the nats repo path for the transport/nats plugin .