### PR TITLE
durable subscriptions for nats streaming

### DIFF
--- a/broker/stan/options.go
+++ b/broker/stan/options.go
@@ -67,3 +67,10 @@ type connectRetryKey struct{}
 func ConnectRetry(v bool) broker.Option {
 	return setBrokerOption(connectRetryKey{}, v)
 }
+
+type durableKey struct{}
+
+// DurableName sets the DurableName for the subscriber
+func DurableName(name string) broker.Option {
+	return setBrokerOption(durableKey{}, name)
+}

--- a/broker/stan/stan.go
+++ b/broker/stan/stan.go
@@ -320,6 +320,11 @@ func (n *stanBroker) Subscribe(topic string, handler broker.Handler, opts ...bro
 
 	opt.AutoAck = !bopts.ManualAcks
 
+	if dn, ok := n.opts.Context.Value(durableKey{}).(string); ok && len(dn) > 0 {
+		stanOpts = append(stanOpts, stan.DurableName(dn))
+		bopts.DurableName = dn
+	}
+
 	fn := func(msg *stan.Msg) {
 		var m broker.Message
 
@@ -367,7 +372,7 @@ func NewBroker(opts ...broker.Option) broker.Broker {
 		o(&options)
 	}
 
-	stanOpts := stan.DefaultOptions
+	stanOpts := stan.GetDefaultOptions()
 	if n, ok := options.Context.Value(optionsKey{}).(stan.Options); ok {
 		stanOpts = n
 	}


### PR DESCRIPTION
1.Provide DurableName options for stan broker
2.Use stan.GetDefaultOptions() instead of stan.DefaultOptions.
For details see https://github.com/nats-io/nats.go/issues/308.