### PR TITLE
changed version of dependency nats.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/nats-io/jwt v0.2.8 // indirect
 	github.com/nats-io/nats-streaming-server v0.15.1 // indirect
-	github.com/nats-io/nats.go v1.8.2-0.20190607221125-9f4d16fe7c2d
+	github.com/nats-io/nats.go v1.8.1
 	github.com/nats-io/stan.go v0.5.0
 	github.com/nsqio/go-nsq v1.0.7
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7

--- a/go.sum
+++ b/go.sum
@@ -426,6 +426,7 @@ github.com/nats-io/nats-server/v2 v2.0.0 h1:rbFV7gfUPErVdKImVMOlW8Qb1V22nlcpqup5
 github.com/nats-io/nats-server/v2 v2.0.0/go.mod h1:RyVdsHHvY4B6c9pWG+uRLpZ0h0XsqiuKp2XCTurP5LI=
 github.com/nats-io/nats-streaming-server v0.15.1 h1:NLQg18mp68e17v+RJpXyPdA7ZH4osFEZQzV3tdxT6/M=
 github.com/nats-io/nats-streaming-server v0.15.1/go.mod h1:bJ1+2CS8MqvkGfr/NwnCF+Lw6aLnL3F5kenM8bZmdCw=
+github.com/nats-io/nats.go v1.8.1 h1:6lF/f1/NN6kzUDBz6pyvQDEXO39jqXcWRLu/tKjtOUQ=
 github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
 github.com/nats-io/nats.go v1.8.2-0.20190607221125-9f4d16fe7c2d h1:deH8qj2gxbSzVDf0aLb6T2YdqLDl82mcRw/WcORFd40=
 github.com/nats-io/nats.go v1.8.2-0.20190607221125-9f4d16fe7c2d/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=


### PR DESCRIPTION
currently go.mod refers to `github.com/nats-io/nats.go v1.8.2-0.20190607221125-9f4d16fe7c2d`. This commit is no longer accessible, presumably due to rebasing (see https://github.com/nats-io/nats.go/issues/493 and https://github.com/golang/go/issues/33076). Therefore, we see an [error](https://travis-ci.org/micro/go-plugins/jobs/557940754#L403) in travis-ci: 

`go: github.com/nats-io/nats.go@v1.8.2-0.20190607221125-9f4d16fe7c2d: unknown revision 9f4d16fe7c2d`.

In a local environment, this error might not occur as `modcache` can still have this commit (`GOPROXY=https://proxy.golang.org` also has this commit). 

This commit changes the dependency's version to the latest tag `1.8.1`. 

related to #374 
