### PR TITLE
Add Service Configuration for AWS snssqs broker plugin

### DIFF
--- a/broker/snssqs/context.go
+++ b/broker/snssqs/context.go
@@ -25,3 +25,13 @@ func setPublishOption(k, v interface{}) broker.PublishOption {
 		o.Context = context.WithValue(o.Context, k, v)
 	}
 }
+
+// setBrokerOption returns a function to setup a context with given value
+func setBrokerOption(k, v interface{}) broker.Option {
+	return func(o *broker.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, k, v)
+	}
+}

--- a/broker/snssqs/options.go
+++ b/broker/snssqs/options.go
@@ -1,10 +1,13 @@
 package snssqs
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/micro/go-micro/broker"
 )
 
 type maxMessagesKey struct{}
+type sqsConfigKey struct{}
+type snsConfigKey struct{}
 
 // MaxReceiveMessages indicates how many messages a receive operation should pull
 // during any single call
@@ -34,4 +37,14 @@ type validateOnPublishKey struct{}
 // This has a significant performance impact
 func ValidateOnPublish(validate bool) broker.PublishOption {
 	return setPublishOption(validateOnPublishKey{}, validate)
+}
+
+// SNSConfig add AWS config options to the sns client
+func SNSConfig(c *aws.Config) broker.PublishOption {
+	return setPublishOption(snsConfigKey{}, c)
+}
+
+// SQSConfig add AWS config options to the sqs client
+func SQSConfig(c *aws.Config) broker.SubscribeOption {
+	return setSubscribeOption(sqsConfigKey{}, c)
 }

--- a/broker/snssqs/options.go
+++ b/broker/snssqs/options.go
@@ -8,6 +8,7 @@ import (
 type maxMessagesKey struct{}
 type sqsConfigKey struct{}
 type snsConfigKey struct{}
+type stsConfigKey struct{}
 
 // MaxReceiveMessages indicates how many messages a receive operation should pull
 // during any single call
@@ -47,4 +48,8 @@ func SNSConfig(c *aws.Config) broker.Option {
 // SQSConfig add AWS config options to the sqs client
 func SQSConfig(c *aws.Config) broker.Option {
 	return setBrokerOption(sqsConfigKey{}, c)
+}
+
+func STSConfig(c *aws.Config) broker.Option {
+	return setBrokerOption(stsConfigKey{}, c)
 }

--- a/broker/snssqs/options.go
+++ b/broker/snssqs/options.go
@@ -40,11 +40,11 @@ func ValidateOnPublish(validate bool) broker.PublishOption {
 }
 
 // SNSConfig add AWS config options to the sns client
-func SNSConfig(c *aws.Config) broker.PublishOption {
-	return setPublishOption(snsConfigKey{}, c)
+func SNSConfig(c *aws.Config) broker.Option {
+	return setBrokerOption(snsConfigKey{}, c)
 }
 
 // SQSConfig add AWS config options to the sqs client
-func SQSConfig(c *aws.Config) broker.SubscribeOption {
-	return setSubscribeOption(sqsConfigKey{}, c)
+func SQSConfig(c *aws.Config) broker.Option {
+	return setBrokerOption(sqsConfigKey{}, c)
 }

--- a/broker/snssqs/snssqs.go
+++ b/broker/snssqs/snssqs.go
@@ -210,7 +210,8 @@ func (b *awsServices) Connect() error {
 	snsConfig := b.getSNSConfig()
 	b.svcSns = sns.New(b.sess, snsConfig)
 
-	svcSts := sts.New(b.sess)
+	stsConfig := b.getSTSConfig()
+	svcSts := sts.New(b.sess, stsConfig)
 
 	input := &sts.GetCallerIdentityInput{}
 
@@ -417,6 +418,14 @@ func (b *awsServices) getSNSConfig() *aws.Config {
 
 func (b *awsServices) getSQSConfig() *aws.Config {
 	raw := b.options.Context.Value(sqsConfigKey{})
+	if raw != nil {
+		return raw.(*aws.Config)
+	}
+	return nil
+}
+
+func (b *awsServices) getSTSConfig() *aws.Config {
+	raw := b.options.Context.Value(stsConfigKey{})
 	if raw != nil {
 		return raw.(*aws.Config)
 	}

--- a/broker/snssqs/snssqs.go
+++ b/broker/snssqs/snssqs.go
@@ -201,10 +201,15 @@ func (b *awsServices) Connect() error {
 
 	b.sess = session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
+		Config:            aws.Config{},
 	}))
 
-	b.svcSqs = sqs.New(b.sess)
-	b.svcSns = sns.New(b.sess)
+	sqsConfig := b.getSQSConfig()
+	b.svcSqs = sqs.New(b.sess, sqsConfig)
+
+	snsConfig := b.getSNSConfig()
+	b.svcSns = sns.New(b.sess, snsConfig)
+
 	svcSts := sts.New(b.sess)
 
 	input := &sts.GetCallerIdentityInput{}
@@ -398,6 +403,22 @@ func (b *awsServices) getAwsClient() *session.Session {
 	if raw != nil {
 		s := raw.(*session.Session)
 		return s
+	}
+	return nil
+}
+
+func (b *awsServices) getSNSConfig() *aws.Config {
+	raw := b.options.Context.Value(snsConfigKey{})
+	if raw != nil {
+		return raw.(*aws.Config)
+	}
+	return nil
+}
+
+func (b *awsServices) getSQSConfig() *aws.Config {
+	raw := b.options.Context.Value(sqsConfigKey{})
+	if raw != nil {
+		return raw.(*aws.Config)
 	}
 	return nil
 }


### PR DESCRIPTION
This allows you to set aws config options on each service used in the snssqs broker. 

For example, this will allow me to utilize localstack for developing services using AWS locally:

```
	snsConfig := &aws.Config{
		Endpoint: aws.String(config.Get("aws", "sns", "endpoint").String("")),
	}
	sqsConfig := &aws.Config{
		Endpoint: aws.String(config.Get("aws", "sqs", "endpoint").String("")),
	}
	stsConfig := &aws.Config{
		Endpoint: aws.String(config.Get("aws", "sts", "endpoint").String("")),
	}
	br := snssqs.NewBroker(
		snssqs.SNSConfig(snsConfig),
		snssqs.SQSConfig(sqsConfig),
		snssqs.STSConfig(stsConfig),
	)
```