### PR TITLE
Fix for configmap values that contain '='

### DIFF
--- a/config/source/configmap/configmap_test.go
+++ b/config/source/configmap/configmap_test.go
@@ -88,6 +88,7 @@ func TestMakeMap(t *testing.T) {
 				"mongodb": "host=127.0.0.1\nport=27017\nuser=user\npassword=password",
 				"config":  "host=0.0.0.0\nport=1337",
 				"redis":   "url=redis://127.0.0.1:6379/db01",
+				"sql":     "username=user\npassword=password=1234",
 			},
 			dout: map[string]interface{}{
 				"mongodb": map[string]interface{}{
@@ -103,8 +104,12 @@ func TestMakeMap(t *testing.T) {
 				"redis": map[string]interface{}{
 					"url": "redis://127.0.0.1:6379/db01",
 				},
+				"sql": map[string]interface{}{
+					"username": "user",
+					"password": "password=1234",
+				},
 			},
-			jdout: []byte(`{"config":{"host":"0.0.0.0","port":"1337"},"mongodb":{"host":"127.0.0.1","password":"password","port":"27017","user":"user"},"redis":{"url":"redis://127.0.0.1:6379/db01"}}`),
+			jdout: []byte(`{"config":{"host":"0.0.0.0","port":"1337"},"mongodb":{"host":"127.0.0.1","password":"password","port":"27017","user":"user"},"redis":{"url":"redis://127.0.0.1:6379/db01"},"sql":{"password":"password=1234","username":"user"}}`),
 		},
 	}
 

--- a/config/source/configmap/util.go
+++ b/config/source/configmap/util.go
@@ -49,6 +49,9 @@ func makeMap(kv map[string]string) map[string]interface{} {
 }
 
 func split(s string, sp string) (k string, v string) {
-	kv := strings.Split(s, sp)
-	return kv[0], kv[1]
+	i := strings.Index(s, sp)
+	if i == -1 {
+		return s, ""
+	}
+	return s[:i], s[i+1:]
 }


### PR DESCRIPTION
This pr is a solution to the issue here: https://github.com/micro/go-plugins/issues/406

The fix changes the split function in the configmap util to only use the first instance of the delimiter so that the entire value after the first is used.
An example would be if a configmap was created as such:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: config
  namespace: test
data:
  sample: "TEST1=test\nTEST2=te=st"
```
Before the change the resulting values would be:
TEST1='test'
TEST2='te'

And after this change they would be:
TEST1='test'
TEST2='test'