### PR TITLE
adding pkger source plugin for go-config

### DIFF
--- a/config/source/pkger/README.md
+++ b/config/source/pkger/README.md
@@ -1,0 +1,30 @@
+# pkger
+
+pkger plugin for `go-config`
+
+### Prerequisites
+
+> Install `pkger` cli
+
+```bash
+go install github.com/markbates/pkger/cmd/pkger
+pkger -h
+```
+
+### Packager
+
+> generating `pkged.go` with all files in `/config` as part of build pipeline
+
+```bash
+pkger -o srv/greeter -include /config
+```
+
+### Usage
+
+```go
+	if err := config.Load(
+		pkger.NewSource(pkger.WithPath("/config/config.yaml")),
+	); err != nil {
+    log.Fatal(err.Error())
+	}
+```

--- a/config/source/pkger/format.go
+++ b/config/source/pkger/format.go
@@ -1,0 +1,15 @@
+package pkger
+
+import (
+	"strings"
+
+	"github.com/micro/go-micro/config/encoder"
+)
+
+func format(p string, e encoder.Encoder) string {
+	parts := strings.Split(p, ".")
+	if len(parts) > 1 {
+		return parts[len(parts)-1]
+	}
+	return e.String()
+}

--- a/config/source/pkger/options.go
+++ b/config/source/pkger/options.go
@@ -1,0 +1,19 @@
+package pkger
+
+import (
+	"context"
+
+	"github.com/micro/go-micro/config/source"
+)
+
+type pkgerPathKey struct{}
+
+// WithPath sets the path to pkger
+func WithPath(p string) source.Option {
+	return func(o *source.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, pkgerPathKey{}, p)
+	}
+}

--- a/config/source/pkger/pkger.go
+++ b/config/source/pkger/pkger.go
@@ -1,0 +1,62 @@
+package pkger
+
+import (
+	"io/ioutil"
+
+	"github.com/markbates/pkger"
+	"github.com/micro/go-micro/config/source"
+)
+
+type file struct {
+	path string
+	opts source.Options
+}
+
+var (
+	DefaultPath = "/config.yaml"
+)
+
+func (f *file) Read() (*source.ChangeSet, error) {
+	fh, err := pkger.Open(f.path)
+	if err != nil {
+		return nil, err
+	}
+	defer fh.Close()
+	b, err := ioutil.ReadAll(fh)
+	if err != nil {
+		return nil, err
+	}
+	info, err := fh.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	cs := &source.ChangeSet{
+		Format:    format(f.path, f.opts.Encoder),
+		Source:    f.String(),
+		Timestamp: info.ModTime(),
+		Data:      b,
+	}
+	cs.Checksum = cs.Sum()
+
+	return cs, nil
+
+}
+
+func (fs *file) Watch() (source.Watcher, error) {
+	return source.NewNoopWatcher()
+}
+
+func (fs *file) String() string {
+	return "pkger"
+}
+
+func NewSource(opts ...source.Option) source.Source {
+	options := source.NewOptions(opts...)
+	path := DefaultPath
+	f, ok := options.Context.Value(pkgerPathKey{}).(string)
+	if ok {
+		path = f
+	}
+	return &file{opts: options, path: path}
+}

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/hudl/fargo v1.3.0
 	github.com/juju/ratelimit v1.0.1
+	github.com/markbates/pkger v0.12.4
 	github.com/micro/cli v0.2.0
 	github.com/micro/go-micro v1.16.0
 	github.com/micro/micro v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -422,6 +422,8 @@ github.com/lucas-clemente/quic-go v0.12.1 h1:BPITli+6KnKogtTxBk2aS4okr5dUHz2LtID
 github.com/lucas-clemente/quic-go v0.12.1/go.mod h1:UXJJPE4RfFef/xPO5wQm0tITK8gNfqwTxjbE7s3Vb8s=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180730094502-03f2033d19d5/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/markbates/pkger v0.12.4 h1:GFMU9NZLyvkBKzrusNhF6oQk8CtJkiRoNBS6PdZFdUU=
+github.com/markbates/pkger v0.12.4/go.mod h1:so/QD8FeTM0IilC3nRArkwOvUT+tsJsaXLFUAKmjzJk=
 github.com/marten-seemann/qpack v0.1.0/go.mod h1:LFt1NU/Ptjip0C2CPkhimBz5CGE3WGDAUWqna+CNTrI=
 github.com/marten-seemann/qtls v0.3.2 h1:O7awy4bHEzSX/K3h+fZig3/Vo03s/RxlxgsAk9sYamI=
 github.com/marten-seemann/qtls v0.3.2/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=


### PR DESCRIPTION
This plugin enables to bundle config resources along with go binary.
 
when no `pkged.go`  is found in the source path, this plugin behaves same as `file` source plugin.
when `pkged.go`  is generates, it will use `pkged.go`  for loading the config data instead of the original file source. 

### Reference
https://blog.gobuffalo.io/introducing-pkger-static-file-embedding-in-go-1ce76dc79c65