### PR TITLE
Extend httpMessage to match server.Message signature

### DIFF
--- a/server/http/http.go
+++ b/server/http/http.go
@@ -180,7 +180,7 @@ func (h *httpServer) Register() error {
 	}
 	h.registered = true
 
-	for sb, _ := range h.subscribers {
+	for sb := range h.subscribers {
 		handler := h.createSubHandler(sb, opts)
 		var subOpts []broker.SubscribeOption
 		if queue := sb.Options().Queue; len(queue) > 0 {

--- a/server/http/message.go
+++ b/server/http/message.go
@@ -1,13 +1,14 @@
 package http
 
+import "github.com/micro/go-micro/codec"
+
 type httpMessage struct {
 	topic       string
-	contentType string
 	payload     interface{}
-}
-
-func (r *httpMessage) ContentType() string {
-	return r.contentType
+	contentType string
+	header      map[string]string
+	body        []byte
+	codec       codec.Reader
 }
 
 func (r *httpMessage) Topic() string {
@@ -16,4 +17,20 @@ func (r *httpMessage) Topic() string {
 
 func (r *httpMessage) Payload() interface{} {
 	return r.payload
+}
+
+func (r *httpMessage) ContentType() string {
+	return r.contentType
+}
+
+func (r *httpMessage) Header() map[string]string {
+	return r.header
+}
+
+func (r *httpMessage) Body() []byte {
+	return r.body
+}
+
+func (r *httpMessage) Codec() codec.Reader {
+	return r.codec
 }

--- a/server/http/subscriber.go
+++ b/server/http/subscriber.go
@@ -55,7 +55,6 @@ func isExportedOrBuiltinType(t reflect.Type) bool {
 }
 
 func newSubscriber(topic string, sub interface{}, opts ...server.SubscriberOption) server.Subscriber {
-
 	options := server.SubscriberOptions{
 		AutoAck: true,
 	}
@@ -259,6 +258,9 @@ func (s *httpServer) createSubHandler(sb *httpSubscriber, opts server.Options) b
 					topic:       sb.topic,
 					contentType: ct,
 					payload:     req.Interface(),
+					header:      msg.Header,
+					body:        msg.Body,
+					codec:       co,
 				})
 			}()
 		}


### PR DESCRIPTION
This commit adds missing server.Message fields to httpMessage.