### PR TITLE
Avoid  excessive checks if topic Exists

### DIFF
--- a/broker/googlepubsub/googlepubsub.go
+++ b/broker/googlepubsub/googlepubsub.go
@@ -10,7 +10,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/micro/go-micro/broker"
 	"github.com/micro/go-micro/config/cmd"
+	"github.com/micro/go-micro/util/log"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type pubsubBroker struct {
@@ -140,22 +143,9 @@ func (b *pubsubBroker) Options() broker.Options {
 }
 
 // Publish checks if the topic exists and then publishes via google pubsub
-func (b *pubsubBroker) Publish(topic string, msg *broker.Message, opts ...broker.PublishOption) error {
+func (b *pubsubBroker) Publish(topic string, msg *broker.Message, opts ...broker.PublishOption) (err error) {
 	t := b.client.Topic(topic)
 	ctx := context.Background()
-
-	exists, err := t.Exists(ctx)
-	if err != nil {
-		return err
-	}
-
-	if !exists {
-		tt, err := b.client.CreateTopic(ctx, topic)
-		if err != nil {
-			return err
-		}
-		t = tt
-	}
 
 	m := &pubsub.Message{
 		ID:         "m-" + uuid.New().String(),
@@ -164,8 +154,16 @@ func (b *pubsubBroker) Publish(topic string, msg *broker.Message, opts ...broker
 	}
 
 	pr := t.Publish(ctx, m)
-	_, err = pr.Get(ctx)
-	return err
+	if _, err = pr.Get(ctx); err != nil {
+		// create Topic if not exists
+		if status.Code(err) == codes.NotFound {
+			log.Logf("Topic not exists. creating Topic: %s", topic)
+			if t, err = b.client.CreateTopic(ctx, topic); err == nil {
+				_, err = t.Publish(ctx, m).Get(ctx)
+			}
+		}
+	}
+	return
 }
 
 // Subscribe registers a subscription to the given topic against the google pubsub api


### PR DESCRIPTION
I am getting **Quota exceeded** error in the stackdriver logs and realized we are doing `if topic Exists` check for every publish action. 
```
error: "rpc error: code = ResourceExhausted desc = Quota exceeded for quota metric 'Administrator read-only operations' and limit 'Administrator read-only operations per minute' of service 'pubsub.googleapis.com' for consumer 'project_number:11111'." 
```
As per google docs, they recommend *try/catch* and create the topic if needed. 

https://cloud.google.com/pubsub/docs/troubleshooting#admin