### PR TITLE
312 - Replace log.Fatal as it's followed by a call to os.Exit(1), fro…

### DIFF
--- a/registry/zookeeper/zookeeper.go
+++ b/registry/zookeeper/zookeeper.go
@@ -62,12 +62,14 @@ func configure(z *zookeeperRegistry, opts ...registry.Option) error {
 	// connect to zookeeper
 	c, _, err := zk.Connect(cAddrs, time.Second*z.options.Timeout)
 	if err != nil {
-		log.Fatal(err)
+		log.Logf(err.Error())
+		return err
 	}
 
 	// create our prefix path
 	if err := createPath(prefix, []byte{}, c); err != nil {
-		log.Fatal(err)
+		log.Logf(err.Error())
+		return err
 	}
 
 	z.client = c
@@ -298,12 +300,14 @@ func NewRegistry(opts ...registry.Option) registry.Registry {
 	// connect to zookeeper
 	c, _, err := zk.Connect(cAddrs, time.Second*options.Timeout)
 	if err != nil {
-		log.Fatal(err)
+		log.Logf(err.Error())
+		return nil
 	}
 
 	// create our prefix path
 	if err := createPath(prefix, []byte{}, c); err != nil {
-		log.Fatal(err)
+		log.Logf(err.Error())
+		return nil
 	}
 
 	return &zookeeperRegistry{


### PR DESCRIPTION
We are using the zookeeper plugin for service registry and we need to be able to recover from errors like this:

Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
zk: could not connect to a server

We saw that during the connection on error it is called log.Fatal which calls os.Exit(1) at the end.