### PR TITLE
Add prefix based path matching to the router

### DIFF
--- a/micro/router/routes.go
+++ b/micro/router/routes.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 	"time"
 )
 
@@ -63,7 +64,7 @@ func (r Route) Match(req *http.Request) bool {
 	rq := r.Request
 
 	// first level match, quick and dirty
-	if (rq.Method == req.Method) && (rq.Host == req.Host) && (rq.Path == req.URL.Path) {
+	if (rq.Method == req.Method) && (rq.Host == req.Host) && strings.HasPrefix(req.URL.Path, rq.Path) {
 		// skip
 	} else {
 		return false

--- a/micro/router/routes_test.go
+++ b/micro/router/routes_test.go
@@ -30,12 +30,21 @@ func TestRoutes(t *testing.T) {
 					},
 					Weight: 1.0,
 				},
+				{
+					Request: Request{
+						Method: "GET",
+						Host:   "bif.com",
+						Path:   "/bif",
+					},
+					Weight: 2.0,
+					Type:   "proxy",
+				},
 			},
 			Req: &http.Request{
 				Method: "GET",
 				Host:   "example.com",
 				URL: &url.URL{
-					Path: "/",
+					Path: "/bif",
 				},
 			},
 			Match: true,
@@ -58,12 +67,95 @@ func TestRoutes(t *testing.T) {
 					},
 					Weight: 1.0,
 				},
+				{
+					Request: Request{
+						Method: "GET",
+						Host:   "bif.com",
+						Path:   "/bif",
+					},
+					Weight: 2.0,
+					Type:   "proxy",
+				},
 			},
 			Req: &http.Request{
 				Method: "POST",
 				Host:   "foo.com",
 				URL: &url.URL{
 					Path: "/bar",
+				},
+			},
+			Match: true,
+		},
+		{
+			Routes: []Route{
+				{
+					Request: Request{
+						Method: "GET",
+						Host:   "example.com",
+						Path:   "/",
+					},
+					Weight: 1.0,
+				},
+				{
+					Request: Request{
+						Method: "POST",
+						Host:   "foo.com",
+						Path:   "/bar",
+					},
+					Weight: 1.0,
+				},
+				{
+					Request: Request{
+						Method: "GET",
+						Host:   "bif.com",
+						Path:   "/bif",
+					},
+					Weight: 2.0,
+					Type:   "proxy",
+				},
+			},
+			Req: &http.Request{
+				Method: "GET",
+				Host:   "bif.com",
+				URL: &url.URL{
+					Path: "/bif",
+				},
+			},
+			Match: true,
+		},
+		{
+			Routes: []Route{
+				{
+					Request: Request{
+						Method: "GET",
+						Host:   "example.com",
+						Path:   "/",
+					},
+					Weight: 1.0,
+				},
+				{
+					Request: Request{
+						Method: "POST",
+						Host:   "foo.com",
+						Path:   "/bar",
+					},
+					Weight: 1.0,
+				},
+				{
+					Request: Request{
+						Method: "GET",
+						Host:   "bif.com",
+						Path:   "/bif",
+					},
+					Weight: 2.0,
+					Type:   "proxy",
+				},
+			},
+			Req: &http.Request{
+				Method: "GET",
+				Host:   "bif.com",
+				URL: &url.URL{
+					Path: "/bif/bam",
 				},
 			},
 			Match: true,


### PR DESCRIPTION
This changes the strict path matching to prefix based path matching, allowing to configure a reverse proxy for more than just a single page.

It will cause routes at `/` to always match if method and host match, but we have the weight to properly address that. I added a test for that case.

This is not yet regex based matching but it is good enough for me.

Let me know what you think.