### PR TITLE
Route sub paths and allow insecure certificates

### DIFF
--- a/micro/router/README.md
+++ b/micro/router/README.md
@@ -25,8 +25,8 @@ Register the plugin before building Micro
 package main
 
 import (
-	"github.com/micro/micro/plugin"
-	"github.com/micro/go-plugins/micro/router"
+	"github.com/micro/micro/v2/plugin"
+	"github.com/micro/go-plugins/micro/router/v2"
 )
 
 func init() {

--- a/micro/router/routes.go
+++ b/micro/router/routes.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"crypto/tls"
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
@@ -23,6 +24,7 @@ type Route struct {
 	Priority int      `json:"priority"` // 0 is highest. Used for ordering routes
 	Weight   float64  `json:"weight"`   // percentage weight between 0 and 1.0
 	Type     string   `json:"type"`     // proxy or response. Response is default
+	Insecure bool     `json:"bool"`     // allow insecure certificates
 }
 
 // Request describes the expected request and will
@@ -104,9 +106,16 @@ func (r Route) Write(w http.ResponseWriter, req *http.Request) {
 			Director: func(rr *http.Request) {
 				rr.URL.Host = r.ProxyURL.Host
 				rr.URL.Scheme = r.ProxyURL.Scheme
-				rr.URL.Path = r.ProxyURL.Path
+				rr.URL.Path = strings.Replace(rr.URL.Path, r.Request.Path, r.ProxyURL.Path, 1)
 				rr.Host = r.ProxyURL.Host
 			},
+		}
+		if r.Insecure {
+			p.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			}
 		}
 		p.ServeHTTP(w, req)
 		return


### PR DESCRIPTION
With this I can properly reverse proxy a web page on another machine.

Also adds an `insecure` route option to allow proxying to self signed https endpoints.