### PR TITLE
Fix log with fields and log with error

### DIFF
--- a/logger/logrus/README.md
+++ b/logger/logrus/README.md
@@ -1,0 +1,25 @@
+# logrus
+
+[logrus](https://github.com/sirupsen/logrus) logger implementation for __go-micro__ [meta logger](https://github.com/micro/go-micro/tree/master/logger).
+
+## Usage
+
+```go
+import (
+	"os"
+	"github.com/sirupsen/logrus"
+	"github.com/micro/go-micro/v2/logger"
+)
+
+func ExampleWithOutput() {
+  logger.DefaultLogger = NewLogger(logger.WithOutput(os.Stdout))
+  logger.Infof(logger.InfoLevel, "testing: %s", "Infof")
+}
+
+func ExampleWithLogger() {
+	l:= logrus.New() // *logrus.Logger
+	logger.DefaultLogger = NewLogger(WithLogger(l))
+  logger.Infof(logger.InfoLevel, "testing: %s", "Infof")
+}
+```
+

--- a/logger/logrus/logrus.go
+++ b/logger/logrus/logrus.go
@@ -9,7 +9,7 @@ import (
 	"github.com/micro/go-micro/v2/logger"
 )
 
-type entryLogger interface {
+type EntryLogger interface {
 	logrus.FieldLogger
 
 	Log(level logrus.Level, args ...interface{})
@@ -17,7 +17,7 @@ type entryLogger interface {
 }
 
 type logrusLogger struct {
-	Logger entryLogger
+	Logger EntryLogger
 	opts   Options
 }
 

--- a/logger/logrus/logrus.go
+++ b/logger/logrus/logrus.go
@@ -69,13 +69,11 @@ func (l *logrusLogger) String() string {
 }
 
 func (l *logrusLogger) Fields(fields map[string]interface{}) logger.Logger {
-	// shall we need pool here?
-	// but logrus already has pool for its entry.
-	return &logrusLogger{logrus.WithFields(fields), l.opts}
+	return &logrusLogger{l.Logger.WithFields(fields), l.opts}
 }
 
 func (l *logrusLogger) Error(err error) logger.Logger {
-	return &logrusLogger{logrus.WithError(err), l.opts}
+	return &logrusLogger{l.Logger.WithError(err), l.opts}
 }
 
 func (l *logrusLogger) Log(level logger.Level, args ...interface{}) {

--- a/logger/logrus/logrus.go
+++ b/logger/logrus/logrus.go
@@ -15,6 +15,7 @@ type logrusLogger struct {
 }
 
 func (l *logrusLogger) Init(opts ...logger.Option) error {
+
 	for _, o := range opts {
 		o(&l.opts.Options)
 	}
@@ -35,14 +36,22 @@ func (l *logrusLogger) Init(opts ...logger.Option) error {
 	log := logrus.New() // defaults
 	if ll, ok := l.opts.Context.Value(logrusLoggerKey{}).(*logrus.Logger); ok {
 		log = ll
-	}
 
-	log.SetOutput(l.opts.Out)
-	log.SetFormatter(l.opts.Formatter)
-	log.ReplaceHooks(l.opts.Hooks)
-	log.SetLevel(loggerToLogrusLevel(l.opts.Level))
-	log.ExitFunc = l.opts.ExitFunc
-	log.SetReportCaller(l.opts.ReportCaller)
+		// overwrite default options
+		l.opts.Level = logrusToLoggerLevel(log.GetLevel())
+		l.opts.Out = log.Out
+		l.opts.Formatter = log.Formatter
+		l.opts.Hooks = log.Hooks
+		l.opts.ReportCaller = log.ReportCaller
+		l.opts.ExitFunc = log.ExitFunc
+	} else {
+		log.SetLevel(loggerToLogrusLevel(l.opts.Level))
+		log.SetOutput(l.opts.Out)
+		log.SetFormatter(l.opts.Formatter)
+		log.ReplaceHooks(l.opts.Hooks)
+		log.SetReportCaller(l.opts.ReportCaller)
+		log.ExitFunc = l.opts.ExitFunc
+	}
 
 	l.Logger = log
 

--- a/logger/logrus/logrus.go
+++ b/logger/logrus/logrus.go
@@ -15,7 +15,6 @@ type logrusLogger struct {
 }
 
 func (l *logrusLogger) Init(opts ...logger.Option) error {
-
 	for _, o := range opts {
 		o(&l.opts.Options)
 	}
@@ -35,15 +34,15 @@ func (l *logrusLogger) Init(opts ...logger.Option) error {
 
 	log := logrus.New() // defaults
 	if ll, ok := l.opts.Context.Value(logrusLoggerKey{}).(*logrus.Logger); ok {
-		log = ll
-
 		// overwrite default options
-		l.opts.Level = logrusToLoggerLevel(log.GetLevel())
-		l.opts.Out = log.Out
-		l.opts.Formatter = log.Formatter
-		l.opts.Hooks = log.Hooks
-		l.opts.ReportCaller = log.ReportCaller
-		l.opts.ExitFunc = log.ExitFunc
+		l.opts.Level = logrusToLoggerLevel(ll.GetLevel())
+		l.opts.Out = ll.Out
+		l.opts.Formatter = ll.Formatter
+		l.opts.Hooks = ll.Hooks
+		l.opts.ReportCaller = ll.ReportCaller
+		l.opts.ExitFunc = ll.ExitFunc
+
+		log = ll
 	} else {
 		log.SetLevel(loggerToLogrusLevel(l.opts.Level))
 		log.SetOutput(l.opts.Out)

--- a/logger/logrus/logrus.go
+++ b/logger/logrus/logrus.go
@@ -9,9 +9,16 @@ import (
 	"github.com/micro/go-micro/v2/logger"
 )
 
+type entryLogger interface {
+	logrus.FieldLogger
+
+	Log(level logrus.Level, args ...interface{})
+	Logf(level logrus.Level, format string, args ...interface{})
+}
+
 type logrusLogger struct {
-	*logrus.Logger
-	opts Options
+	Logger entryLogger
+	opts   Options
 }
 
 func (l *logrusLogger) Init(opts ...logger.Option) error {
@@ -64,11 +71,11 @@ func (l *logrusLogger) String() string {
 func (l *logrusLogger) Fields(fields map[string]interface{}) logger.Logger {
 	// shall we need pool here?
 	// but logrus already has pool for its entry.
-	return &logrusLogger{logrus.WithFields(fields).Logger, l.opts}
+	return &logrusLogger{logrus.WithFields(fields), l.opts}
 }
 
 func (l *logrusLogger) Error(err error) logger.Logger {
-	return &logrusLogger{logrus.WithError(err).Logger, l.opts}
+	return &logrusLogger{logrus.WithError(err), l.opts}
 }
 
 func (l *logrusLogger) Log(level logger.Level, args ...interface{}) {

--- a/logger/logrus/logrus_test.go
+++ b/logger/logrus/logrus_test.go
@@ -40,14 +40,15 @@ func TestWithError(t *testing.T) {
 }
 
 func TestWithLogger(t *testing.T) {
+	// with *logrus.Logger
 	l := NewLogger(WithLogger(logrus.StandardLogger())).Fields(map[string]interface{}{
 		"k1": "v1",
 		"k2": 123456,
 	})
 	logger.DefaultLogger = l
-
 	logger.Log(logger.InfoLevel, "testing: with *logrus.Logger")
 
+	// with *logrus.Entry
 	el := NewLogger(WithLogger(logrus.NewEntry(logrus.StandardLogger()))).Fields(map[string]interface{}{
 		"k3": 3.456,
 		"k4": true,

--- a/logger/logrus/logrus_test.go
+++ b/logger/logrus/logrus_test.go
@@ -39,6 +39,23 @@ func TestWithError(t *testing.T) {
 	logger.Log(logger.InfoLevel, "testing: error")
 }
 
+func TestWithLogger(t *testing.T) {
+	l := NewLogger(WithLogger(logrus.StandardLogger())).Fields(map[string]interface{}{
+		"k1": "v1",
+		"k2": 123456,
+	})
+	logger.DefaultLogger = l
+
+	logger.Log(logger.InfoLevel, "testing: with *logrus.Logger")
+
+	el := NewLogger(WithLogger(logrus.NewEntry(logrus.StandardLogger()))).Fields(map[string]interface{}{
+		"k3": 3.456,
+		"k4": true,
+	})
+	logger.DefaultLogger = el
+	logger.Log(logger.InfoLevel, "testing: with *logrus.Entry")
+}
+
 func TestJSON(t *testing.T) {
 	logger.DefaultLogger = NewLogger(WithJSONFormatter(&logrus.JSONFormatter{}))
 

--- a/logger/logrus/logrus_test.go
+++ b/logger/logrus/logrus_test.go
@@ -1,6 +1,7 @@
 package logrus
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -20,10 +21,22 @@ func TestName(t *testing.T) {
 }
 
 func TestWithFields(t *testing.T) {
-	logger.DefaultLogger = NewLogger(logger.WithOutput(os.Stdout))
+	l := NewLogger(logger.WithOutput(os.Stdout)).Fields(map[string]interface{}{
+		"k1": "v1",
+		"k2": 123456,
+	})
+
+	logger.DefaultLogger = l
 
 	logger.Log(logger.InfoLevel, "testing: Info")
 	logger.Logf(logger.InfoLevel, "testing: %s", "Infof")
+}
+
+func TestWithError(t *testing.T) {
+	l := NewLogger().Error(errors.New("boom!"))
+	logger.DefaultLogger = l
+
+	logger.Log(logger.InfoLevel, "testing: error")
 }
 
 func TestJSON(t *testing.T) {

--- a/logger/logrus/options.go
+++ b/logger/logrus/options.go
@@ -47,6 +47,6 @@ func WithExitFunc(exit func(int)) logger.Option {
 
 type logrusLoggerKey struct{}
 
-func WithLogger(l EntryLogger) logger.Option {
+func WithLogger(l logrus.StdLogger) logger.Option {
 	return logger.SetOption(logrusLoggerKey{}, l)
 }

--- a/logger/logrus/options.go
+++ b/logger/logrus/options.go
@@ -47,6 +47,6 @@ func WithExitFunc(exit func(int)) logger.Option {
 
 type logrusLoggerKey struct{}
 
-func WithLogger(l *logrus.Logger) logger.Option {
+func WithLogger(l EntryLogger) logger.Option {
 	return logger.SetOption(logrusLoggerKey{}, l)
 }


### PR DESCRIPTION
- Fix #499 
- Added `func WithLogger(l logrus.StdLogger) logger.Option`. Allow to initialize `Logger` with an existing `*logrus.Logger` or `*logrus.Entry`.