### PR TITLE
Add support for specifying priority when publishing a message to rabbitmq

### DIFF
--- a/broker/rabbitmq/options.go
+++ b/broker/rabbitmq/options.go
@@ -14,6 +14,7 @@ type prefetchGlobalKey struct{}
 type exchangeKey struct{}
 type requeueOnErrorKey struct{}
 type deliveryMode struct{}
+type priorityKey struct{}
 type externalAuth struct{}
 type durableExchange struct{}
 
@@ -60,6 +61,11 @@ func PrefetchGlobal() broker.Option {
 // DeliveryMode sets a delivery mode for publishing
 func DeliveryMode(value uint8) broker.PublishOption {
 	return setPublishOption(deliveryMode{}, value)
+}
+
+// Priority sets a priority level for publishing
+func Priority(value uint8) broker.PublishOption {
+	return setPublishOption(priorityKey{}, value)
 }
 
 func ExternalAuth() broker.Option {

--- a/broker/rabbitmq/rabbitmq.go
+++ b/broker/rabbitmq/rabbitmq.go
@@ -158,6 +158,10 @@ func (r *rbroker) Publish(topic string, msg *broker.Message, opts ...broker.Publ
 		if value, ok := options.Context.Value(deliveryMode{}).(uint8); ok {
 			m.DeliveryMode = value
 		}
+
+		if value, ok := options.Context.Value(priorityKey{}).(uint8); ok {
+			m.Priority = value
+		}
 	}
 
 	for k, v := range msg.Header {


### PR DESCRIPTION
Since RabbitMQ version 3.5.0 priority queues are supported - https://www.rabbitmq.com/priority.html

When publishing a message `Priority` property can be set to declare the, well, priority of the message.

This PR adds support for this