### PR TITLE
Fixed nsq one queue run multiple times handlers, micro/go-micro#1209

### DIFF
--- a/broker/nsq/nsq.go
+++ b/broker/nsq/nsq.go
@@ -265,6 +265,7 @@ func (n *nsqBroker) Subscribe(topic string, handler broker.Handler, opts ...brok
 		if err := n.opts.Codec.Unmarshal(nm.Body, &m); err != nil {
 			return err
 		}
+		m.Header["Queue"] = channel
 
 		p := &publication{topic: topic, m: &m}
 		p.err = handler(p)


### PR DESCRIPTION
If nsq broker subscribe with three queues, message will run 3*3=9 times handlers

https://github.com/micro/go-micro/issues/1209

I add pr to go-micro also.
https://github.com/micro/go-micro/commit/46363dbacbe5d1171c287cbcf042491e0c5c08bd