### PR TITLE
Fix wrong address format like `192.168.100.18:5495:5495`

### DIFF
--- a/registry/eureka/marshalling.go
+++ b/registry/eureka/marshalling.go
@@ -48,10 +48,12 @@ func appToService(app *fargo.Application) []*registry.Service {
 			}
 		}
 
+                host, _, _ := net.SplitHostPort(addr)
+
 		// append node
 		service.Nodes = append(service.Nodes, &registry.Node{
 			Id:       id,
-			Address:  fmt.Sprintf("%s:%d", addr, port),
+			Address:  fmt.Sprintf("%s:%d", host, port),
 			Metadata: metadata,
 		})
 


### PR DESCRIPTION
the `addr` may append port in which case it would cause invalid address