### PR TITLE
refactor: default consul config

### DIFF
--- a/registry/consul/consul.go
+++ b/registry/consul/consul.go
@@ -81,8 +81,8 @@ func configure(c *consulRegistry, opts ...registry.Option) {
 		o(&c.opts)
 	}
 
-	// use default config
-	config := consul.DefaultConfig()
+	// use default non pooled config
+	config := consul.DefaultNonPooledConfig()
 
 	if c.opts.Context != nil {
 		// Use the consul config passed in the options, if available


### PR DESCRIPTION
Default consul config make too many connects, and consul has default limits: http_max_conns_per_client=200. 
The service will register fail when you run more then 10 services