### PR TITLE
broker snssqs - add header validation and whitelist support

### DIFF
--- a/broker/snssqs/options.go
+++ b/broker/snssqs/options.go
@@ -7,9 +7,6 @@ import (
 )
 
 type maxMessagesKey struct{}
-type sqsConfigKey struct{}
-type snsConfigKey struct{}
-type stsConfigKey struct{}
 
 // MaxReceiveMessages indicates how many messages a receive operation should pull
 // during any single call
@@ -45,16 +42,47 @@ func ClientValidateOnPublish(validate bool) client.PublishOption {
 	return setClientPublishOption(validateOnPublishKey{}, validate)
 }
 
+type snsConfigKey struct{}
+
 // SNSConfig add AWS config options to the sns client
 func SNSConfig(c *aws.Config) broker.Option {
 	return setBrokerOption(snsConfigKey{}, c)
 }
+
+type sqsConfigKey struct{}
 
 // SQSConfig add AWS config options to the sqs client
 func SQSConfig(c *aws.Config) broker.Option {
 	return setBrokerOption(sqsConfigKey{}, c)
 }
 
+type stsConfigKey struct{}
+
+// STSConfig add AWS config options to the sts client
 func STSConfig(c *aws.Config) broker.Option {
 	return setBrokerOption(stsConfigKey{}, c)
+}
+
+type validateHeaderOnPublishKey struct{}
+
+// ValidateHeaderOnPublish validate headers before sending to sns
+func ValidateHeaderOnPublish(validate bool) broker.PublishOption {
+	return setPublishOption(validateHeaderOnPublishKey{}, validate)
+}
+
+// ClientValidateHeaderOnPublish validate headers before sending to sns
+func ClientValidateHeaderOnPublish(validate bool) client.PublishOption {
+	return setClientPublishOption(validateHeaderOnPublishKey{}, validate)
+}
+
+type headerWhitelistOnPublishKey struct{}
+
+// HeaderWhitelist validate headers before sending to sns
+func HeaderWhitelistOnPublish(whitelist map[string]struct{}) broker.PublishOption {
+	return setPublishOption(headerWhitelistOnPublishKey{}, whitelist)
+}
+
+// ClientHeaderWhitelist validate headers before sending to sns
+func ClientHeaderWhitelistOnPublish(whitelist map[string]struct{}) client.PublishOption {
+	return setClientPublishOption(headerWhitelistOnPublishKey{}, whitelist)
 }

--- a/broker/snssqs/snssqs_test.go
+++ b/broker/snssqs/snssqs_test.go
@@ -26,8 +26,8 @@ func TestValidate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := Validate(tt.msg); (err != nil) != tt.wantErr {
-				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			if err := ValidateBody(tt.msg); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateBody() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
sns/sqs only allow 10 attributes when publishing a message. Due to how we are copying the message header this can be exceeded depending on other parts of go-micro and additional tooling are adding to requests along the way. If you exceed 10 attributes will make its way into sns/sqs and silently fail. Additionally, http2 headers like :authority contain invalid characters for sns/sqs and cause it to fail as well.

So this change allows for the detection of these to cases and additionally adds support for whitelisting header attributes so that users can ensure delivery.