### PR TITLE
fix: call Close on the zlib ReadCloser when done

### DIFF
--- a/registry/consul/encoding.go
+++ b/registry/consul/encoding.go
@@ -39,6 +39,7 @@ func decode(d string) []byte {
 	if err != nil {
 		return nil
 	}
+	zr.Close()
 
 	return rbuf
 }


### PR DESCRIPTION
when there was many rpc calls decode will use a lot of memeory, so we should close the zlib reader