### PR TITLE
wrapper/trace/opentracing: fix tracing key title case

### DIFF
--- a/wrapper/trace/opentracing/opentracing.go
+++ b/wrapper/trace/opentracing/opentracing.go
@@ -4,6 +4,7 @@ package opentracing
 import (
 	"fmt"
 
+	"strings"
 	"context"
 
 	"github.com/micro/go-micro/v2/client"
@@ -36,10 +37,15 @@ func StartSpanFromContext(ctx context.Context, tracer opentracing.Tracer, name s
 		opts = append(opts, opentracing.ChildOf(spanCtx))
 	}
 
+	newMD := make(metadata.Metadata)
 	sp := tracer.StartSpan(name, opts...)
 
 	if err := sp.Tracer().Inject(sp.Context(), opentracing.TextMap, opentracing.TextMapCarrier(md)); err != nil {
 		return nil, nil, err
+	}
+
+	for k, v := range newMD {
+		md.Set(strings.Title(k), v)
 	}
 
 	ctx = opentracing.ContextWithSpan(ctx, sp)


### PR DESCRIPTION
In `metadata.FromContext(ctx)` All keys are titled case using `strings.Title`.  

But 
```
sp.Tracer().Inject(sp.Context(), opentracing.TextMap, opentracing.TextMapCarrier(newMd))
```
 only insert SpanID, TraceID in lower-case. This will lead to span information missing issue.