### PR TITLE
fix readme import path for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Import the plugins in a `plugins.go` file
 package main
 
 import (
-	_ "github.com/micro/go-plugins/broker/rabbitmq"
-	_ "github.com/micro/go-plugins/registry/kubernetes"
-	_ "github.com/micro/go-plugins/transport/nats"
+	_ "github.com/micro/go-plugins/broker/rabbitmq/v2"
+	_ "github.com/micro/go-plugins/registry/kubernetes/v2"
+	_ "github.com/micro/go-plugins/transport/nats/v2"
 )
 ```
 
@@ -102,7 +102,7 @@ Import and set as options when creating a new service
 ```go
 import (
 	"github.com/micro/go-micro/v2"
-	"github.com/micro/go-plugins/registry/kubernetes"
+	"github.com/micro/go-plugins/registry/kubernetes/v2"
 )
 
 func main() {
@@ -129,9 +129,9 @@ Create file plugins.go
 package main
 
 import (
-	_ "github.com/micro/go-plugins/broker/rabbitmq"
-	_ "github.com/micro/go-plugins/registry/kubernetes"
-	_ "github.com/micro/go-plugins/transport/nats"
+	_ "github.com/micro/go-plugins/broker/rabbitmq/v2"
+	_ "github.com/micro/go-plugins/registry/kubernetes/v2"
+	_ "github.com/micro/go-plugins/transport/nats/v2"
 )
 ```
 


### PR DESCRIPTION
Hi, after I followed the Usage Instructions, I got errors.  

`go run plugins.go --broker=rabbitmq --registry=kubernetes --transport=nats`

```
2020-06-18 16:51:33.922603 I | WARNING: proto: message go.micro.broker.Empty is already registered
A future release will panic on registration conflicts. See:
https://developers.google.com/protocol-buffers/docs/reference/go/faq#namespace-conflict

2020-06-18 16:51:33.922629 I | WARNING: proto: message go.micro.broker.PublishRequest is already registered
A future release will panic on registration conflicts. See:
https://developers.google.com/protocol-buffers/docs/reference/go/faq#namespace-conflict

2020-06-18 16:51:33.922649 I | WARNING: proto: message go.micro.broker.SubscribeRequest is already registered
A future release will panic on registration conflicts. See:
https://developers.google.com/protocol-buffers/docs/reference/go/faq#namespace-conflict

2020-06-18 16:51:33.922660 I | WARNING: proto: message go.micro.broker.Message is already registered
A future release will panic on registration conflicts. See:
https://developers.google.com/protocol-buffers/docs/reference/go/faq#namespace-conflict

panic: proto: duplicate proto message registered: go.micro.broker.Message.HeaderEntry

goroutine 1 [running]:
github.com/golang/protobuf/proto.RegisterMapType(0x4e58320, 0x0, 0x506f26e, 0x23)
	/mnt/htdocs/farm/go/pkg/mod/github.com/golang/protobuf@v1.4.0/proto/registry.go:203 +0x1cb
github.com/micro/go-micro/broker/service/proto.init.0()
	/mnt/htdocs/farm/go/pkg/mod/github.com/micro/go-micro@v1.16.0/broker/service/proto/broker.pb.go:202 +0x107
exit status 2
```

It confused me quite a while. 

P.S. https://m3o.com/docs/plugins-framework.html has the same problem.